### PR TITLE
Bump version: 0.1.0 → 0.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/fagfunksjoner/__init__.py
+++ b/fagfunksjoner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 from .paths.project_root import ProjectRoot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-fagfunksjoner"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fellesfunksjoner for ssb i Python"
 authors = ["SSB-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Testing pushing with new github action, because changes in jupyterlab git extension automatically pushes tags now.