### PR TITLE
Datadok trying many possible paths + utility functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-fagfunksjoner"
-version = "1.0.1"
+version = "1.0.2"
 description = "Fellesfunksjoner for ssb i Python"
 authors = ["SSB-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -665,7 +665,7 @@ def raise_on_missing_future_publish(
         else:
             logger.warning(msg)
             return next_time
-    
+
     elif isinstance(next_time, datetime.timedelta) and next_time < zerotime:
         msg = f"You haven't added a next publishing to the register yet? {next_time.days} days since last publishing?"
         if raise_error:

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -62,9 +62,9 @@ class LangText:
     """Represents a text with a language attribute.
 
     Attributes:
-        lang (str): The language code.
-        text (None | str): The text in the specified language.
-        navn (None): Unused attribute, kept for compatibility.
+        lang: The language code.
+        text: The text in the specified language.
+        navn: Unused attribute, kept for compatibility.
     """
 
     lang: str
@@ -77,7 +77,7 @@ class Navn:
     """Represents a list of LangText objects.
 
     Attributes:
-        navn_lang (list[LangText]): A list of LangText objects.
+        navn_lang: A list of LangText objects.
     """
 
     navn_lang: list[LangText]
@@ -88,12 +88,12 @@ class Kontakt:
     """Represents a contact with various attributes.
 
     Attributes:
-        navn (list[LangText]): A list of LangText objects representing names.
-        statid (str): The contact ID.
-        telefon (str): The contact's phone number.
-        mobil (str): The contact's mobile number.
-        epost (str): The contact's email address.
-        initialer (str): The contact's initials.
+        navn: A list of LangText objects representing names.
+        statid: The contact ID.
+        telefon: The contact's phone number.
+        mobil: The contact's mobile number.
+        epost: The contact's email address.
+        initialer: The contact's initials.
     """
 
     navn: list[LangText]
@@ -109,9 +109,9 @@ class Eierseksjon:
     """Represents an ownership section with various attributes.
 
     Attributes:
-        navn (list[LangText]): A list of LangText objects representing names.
-        statid (str): The section ID.
-        navn_attr (str): The section name.
+        navn: A list of LangText objects representing names.
+        statid: The section ID.
+        navn_attr: The section name.
     """
 
     navn: list[LangText]
@@ -123,13 +123,13 @@ class Variant:
     """Represents a variant with various attributes.
 
     Attributes:
-        navn (str): The name of the variant.
-        statid (str): The variant ID.
-        revisjon (str): The revision of the variant.
-        opphort (str): Whether the variant is discontinued.
-        detaljniva (str): Detailed level information.
-        detaljniva_EN (str): Detailed level information in English.
-        frekvens (str): The frequency of the variant.
+        navn: The name of the variant.
+        statid: The variant ID.
+        revisjon: The revision of the variant.
+        opphort: Whether the variant is discontinued.
+        detaljniva: Detailed level information.
+        detaljniva_EN: Detailed level information in English.
+        frekvens: The frequency of the variant.
     """
 
     navn: str
@@ -146,23 +146,23 @@ class SinglePublishing:
     """Represents a single publishing entry with various attributes.
 
     Attributes:
-        navn (Navn): The name details.
-        kortnavn (str): The short name.
-        gamleEmnekoder (str): The old subject codes.
-        forstegangspublisering (str): The first publication date.
-        status (str): The status code.
-        eierseksjon (Eierseksjon): The ownership section details.
-        kontakter (list[Kontakt]): A list of contacts.
-        triggerord (dict[str, list[dict[str, str]]]): A dictionary of trigger words.
-        varianter (list[Variant]): A list of variants.
-        regionaleNivaer (list[str]): A list of regional levels.
-        videreforing (dict): A dictionary of continuation information.
-        statid (str): The ID of the publishing entry.
-        defaultLang (str): The default language code.
-        godkjent (str): Approval status.
-        endret (str): The last modified date.
-        deskFlyt (str): Desk flow status.
-        dirFlyt (str): Directory flow status.
+        navn: The name details.
+        kortnavn: The short name.
+        gamleEmnekoder: The old subject codes.
+        forstegangspublisering: The first publication date.
+        status: The status code.
+        eierseksjon: The ownership section details.
+        kontakter: A list of contacts.
+        triggerord: A dictionary of trigger words.
+        varianter: A list of variants.
+        regionaleNivaer: A list of regional levels.
+        videreforing: A dictionary of continuation information.
+        statid: The ID of the publishing entry.
+        defaultLang: The default language code.
+        godkjent: Approval status.
+        endret: The last modified date.
+        deskFlyt: Desk flow status.
+        dirFlyt: Directory flow status.
     """
 
     navn: Navn
@@ -188,7 +188,7 @@ def parse_lang_text_single(entry: dict[str, Any]) -> LangText:
     """Parses a dictionary entry into a LangText object.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         LangText: The parsed LangText object.
@@ -204,7 +204,7 @@ def parse_navn_single(entry: dict[str, Any]) -> Navn:
     """Parses a dictionary entry into a Navn object.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         Navn: The parsed Navn object.
@@ -216,7 +216,7 @@ def parse_kontakt_single(entry: dict[str, Any]) -> Kontakt:
     """Parses a dictionary entry into a Kontakt object.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         Kontakt: The parsed Kontakt object.
@@ -236,7 +236,7 @@ def parse_eierseksjon_single(entry: dict[str, Any]) -> Eierseksjon:
     """Parses a dictionary entry into an Eierseksjon object.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         Eierseksjon: The parsed Eierseksjon object.
@@ -249,7 +249,7 @@ def parse_triggerord_single(entry: dict[str, Any]) -> dict[str, str]:
     """Parses a dictionary entry into a trigger word dictionary.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         dict: The parsed trigger word dictionary.
@@ -264,7 +264,7 @@ def parse_variant_single(entry: dict[str, Any]) -> Variant:
     """Parses a dictionary entry into a Variant object.
 
     Args:
-        entry (dict[str, Any]): The dictionary entry to parse.
+        entry: The dictionary entry to parse.
 
     Returns:
         Variant: The parsed Variant object.
@@ -284,7 +284,7 @@ def parse_data_single(root: dict[str, Any]) -> SinglePublishing:
     """Parses the root dictionary into a SinglePublishing object.
 
     Args:
-        root (dict[str, Any]): The root dictionary to parse.
+        root: The root dictionary to parse.
 
     Returns:
         SinglePublishing: The parsed SinglePublishing object.
@@ -350,7 +350,7 @@ def kwargs_specifics(nested: dict[str, Any]) -> dict[str, Any]:
     """Map fields in specifics to kwargs for the dataclass.
 
     Args:
-        nested (dict[str, Any]): The XML-datastructure to map.
+        nested: The XML-datastructure to map.
 
     Returns:
         dict[str, Any]: Cleaned up data-structure
@@ -397,10 +397,10 @@ def find_stat_shortcode(
     """Find the data for a statistical product by searching by its shortname.
 
     Args:
-        shortcode_or_id (str): The shortname for the statistical product. Defaults to "trosamf".
-        get_singles (bool): Get more single data. Defaults to True.
-        get_publishings (bool): Get more publishing data. Defaults to True.
-        get_publishing_specifics (bool): Get the specific publishings data as well. Defaults to True.
+        shortcode_or_id: The shortname for the statistical product. Defaults to "trosamf".
+        get_singles: Get more single data. Defaults to True.
+        get_publishings: Get more publishing data. Defaults to True.
+        get_publishing_specifics: Get the specific publishings data as well. Defaults to True.
 
     Returns:
         list[dict[str, Any]]: A data structure containing the found data on the product.
@@ -432,7 +432,7 @@ def single_stat(stat_id: str = "4922") -> SinglePublishing:
     """Get the metadata for specific product.
 
     Args:
-        stat_id (str): The ID for the product in statistikkregisteret. Defaults to "4922".
+        stat_id: The ID for the product in statistikkregisteret. Defaults to "4922".
 
     Returns:
         SinglePublishing: Datastructure with the found metadata.
@@ -451,8 +451,8 @@ def find_publishings(
     """Get the publishings for a specific shortcode.
 
     Args:
-        shortname (str): The shortcode to look for in the API among the publishings. Defaults to "trosamf".
-        get_publishing_specifics (bool): Looks up more info about each of the publishings found. Defaults to True.
+        shortname: The shortcode to look for in the API among the publishings. Defaults to "trosamf".
+        get_publishing_specifics: Looks up more info about each of the publishings found. Defaults to True.
 
     Returns:
         MultiplePublishings: A datastructure with the found metadata about the statistics.
@@ -496,7 +496,7 @@ def time_until_publishing(shortname: str = "trosamf") -> datetime.timedelta | No
     Returns a negative timedelta, if there is no future publishing recorded.
 
     Args:
-        shortname (str): The shortcode to look for in the API among the publishings. Defaults to "trosamf".
+        shortname: The shortcode to look for in the API among the publishings. Defaults to "trosamf".
 
     Returns:
         datetime.timedelta | None : The time difference between now, and the latest publishing date.
@@ -521,7 +521,7 @@ def find_latest_publishing(
     """Find the date of the latest publishing of the statistical product.
 
     Args:
-        shortname (str): The shortname to find the latest publishing for. Defaults to "trosamf".
+        shortname: The shortname to find the latest publishing for. Defaults to "trosamf".
 
     Returns:
         StatisticPublishingShort | None: data about the specific publishing. Or None if nothing is found.
@@ -549,7 +549,7 @@ def specific_publishing(publish_id: str = "162143") -> PublishingSpecifics:
     """Get the publishing-data from a specific publishing-ID in statistikkregisteret.
 
     Args:
-        publish_id (str): The API-ID for the publishing. Defaults to "162143".
+        publish_id: The API-ID for the publishing. Defaults to "162143".
 
     Returns:
         PublishingSpecifics: The metadata found for the specific publishing.
@@ -565,7 +565,7 @@ def etree_to_dict(t: ET.Element) -> dict[str, Any]:
     """Convert an XML-tree to a python dictionary.
 
     Args:
-        t (ET): The XML element to convert.
+        t: The XML element to convert.
 
     Returns:
         dict[str, Any]: The python dictionary that has been converted to.

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -409,25 +409,33 @@ def find_stat_shortcode(
     results = []
     for stat in register:
         if shortcode_or_id.isdigit() and shortcode_or_id == stat["id"]:
-            return get_singles_publishings(stat,
-                            shortcode_or_id,
-                            get_singles,
-                            get_publishings,
-                            get_publishing_specifics)
+            return get_singles_publishings(
+                stat,
+                shortcode_or_id,
+                get_singles,
+                get_publishings,
+                get_publishing_specifics,
+            )
         elif shortcode_or_id in stat["shortName"]:
-            results.append(get_singles_publishings(stat,
-                            stat["id"],
-                            get_singles,
-                            get_publishings,
-                            get_publishing_specifics))
+            results.append(
+                get_singles_publishings(
+                    stat,
+                    stat["id"],
+                    get_singles,
+                    get_publishings,
+                    get_publishing_specifics,
+                )
+            )
     return results
 
 
-def get_singles_publishings(stat: dict[str, Any],
-                            shortcode_or_id: str = "trosamf",
-                            get_singles: bool = True,
-                            get_publishings: bool = True,
-                            get_publishing_specifics: bool = True,): 
+def get_singles_publishings(
+    stat: dict[str, Any],
+    shortcode_or_id: str = "trosamf",
+    get_singles: bool = True,
+    get_publishings: bool = True,
+    get_publishing_specifics: bool = True,
+) -> dict[str, Any]:
     """Find the data for a statistical product by searching by its shortname.
 
     Args:
@@ -447,6 +455,7 @@ def get_singles_publishings(stat: dict[str, Any],
             stat["shortName"], get_publishing_specifics
         )
     return stat
+
 
 @lru_cache(maxsize=128)
 def single_stat(stat_id: str = "4922") -> SinglePublishing:
@@ -606,13 +615,14 @@ def etree_to_dict(t: ET.Element) -> dict[str, Any]:
             d[t.tag] = text
     return d
 
+
 def handle_children(children: list[ET.Element], t: ET.Element) -> dict[str, Any]:
     """Handle children in the etree.
-    
+
     Args:
         children: The children to treat.
         t: The XML element to convert.
-    
+
     Returns:
         dict[str, Any]: The python dictionary of the children part.
     """

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -659,7 +659,7 @@ def raise_on_missing_future_publish(
     zerotime = datetime.timedelta(0)
     next_time = time_until_publishing(shortname)
     if next_time is None:
-        msg = "Cant find any publishing times for {shortname}. Are you using the correct shortname?"
+        msg = f"Cant find any publishing times for {shortname}. Are you using the correct shortname?"
         if raise_error:
             raise FuturePublishingError(msg)
         else:

--- a/src/fagfunksjoner/api/valuta.py
+++ b/src/fagfunksjoner/api/valuta.py
@@ -345,7 +345,7 @@ def make_single_dataframe_record(
     Returns:
         dict[str, str | float]: A dictionary representing a single record in the DataFrame.
     """
-    record = {
+    record: dict[str, str | float] = {
         **{
             dim.id: dim.values[int(series_key.split(":")[dim.keyPosition])]["name"]
             for dim in structure_obj.dimensions.get("series", [])

--- a/src/fagfunksjoner/api/valuta.py
+++ b/src/fagfunksjoner/api/valuta.py
@@ -11,10 +11,10 @@ class Link:
     """Represents a hyperlink related to the dataset.
 
     Args:
-        rel (str): The relationship type of the link.
-        href (str | None): The URL of the link (if available).
-        uri (str | None): The URI of the link (if available).
-        urn (str | None): The URN of the link (if available).
+        rel: The relationship type of the link.
+        href: The URL of the link (if available).
+        uri: The URI of the link (if available).
+        urn: The URN of the link (if available).
     """
 
     rel: str
@@ -28,7 +28,7 @@ class Sender:
     """Represents the sender of the dataset.
 
     Args:
-        id (str): The identifier of the sender.
+        id: The identifier of the sender.
     """
 
     id: str
@@ -39,7 +39,7 @@ class Receiver:
     """Represents the receiver of the dataset.
 
     Args:
-        id (str): The identifier of the receiver.
+        id: The identifier of the receiver.
     """
 
     id: str
@@ -50,13 +50,13 @@ class ValutaMeta:
     """Metadata related to the dataset.
 
     Args:
-        id (str): The identifier of the metadata.
-        prepared (str): The preparation timestamp of the metadata.
-        test (bool): Indicates if the dataset is a test.
-        datasetId (str): The identifier of the dataset.
-        sender (Sender): The sender of the dataset.
-        receiver (Receiver): The receiver of the dataset.
-        links (list[Link]): A list of related links.
+        id: The identifier of the metadata.
+        prepared: The preparation timestamp of the metadata.
+        test: Indicates if the dataset is a test.
+        datasetId: The identifier of the dataset.
+        sender: The sender of the dataset.
+        receiver : The receiver of the dataset.
+        links: A list of related links.
     """
 
     id: str
@@ -73,12 +73,12 @@ class Observation:
     """Represents an observation within the dataset.
 
     Args:
-        id (str): The identifier of the observation.
-        name (str): The name of the observation.
-        description (str): The description of the observation.
-        keyPosition (int): The key position of the observation in the dataset.
-        role (str | None): The role of the observation (if any).
-        values (list[dict[str, str | float]]): The values associated with the observation.
+        id: The identifier of the observation.
+        name: The name of the observation.
+        description: The description of the observation.
+        keyPosition: The key position of the observation in the dataset.
+        role: The role of the observation (if any).
+        values: The values associated with the observation.
     """
 
     id: str
@@ -94,12 +94,12 @@ class Attribute:
     """Represents an attribute within the dataset.
 
     Args:
-        id (str): The identifier of the attribute.
-        name (str): The name of the attribute.
-        description (str): The description of the attribute.
-        relationship (dict[str, list[str]]): The relationship of the attribute to dimensions.
-        role (str | None): The role of the attribute (if any).
-        values (list[dict[str, str]]): The values associated with the attribute.
+        id: The identifier of the attribute.
+        name: The name of the attribute.
+        description: The description of the attribute.
+        relationship: The relationship of the attribute to dimensions.
+        role: The role of the attribute (if any).
+        values: The values associated with the attribute.
     """
 
     id: str
@@ -115,12 +115,12 @@ class Dimension:
     """Represents a dimension within the dataset.
 
     Args:
-        id (str): The identifier of the dimension.
-        name (str): The name of the dimension.
-        description (str): The description of the dimension.
-        keyPosition (int): The key position of the dimension in the dataset.
-        role (str | None): The role of the dimension (if any).
-        values (list[dict[str, str]]): The values associated with the dimension.
+        id: The identifier of the dimension.
+        name: The name of the dimension.
+        description: The description of the dimension.
+        keyPosition: The key position of the dimension in the dataset.
+        role: The role of the dimension (if any).
+        values: The values associated with the dimension.
     """
 
     id: str
@@ -136,13 +136,13 @@ class Structure:
     """Represents the structure of the dataset.
 
     Args:
-        links (list[Link]): A list of related links.
-        name (str): The name of the structure.
-        names (dict[str, str]): A dictionary of names in different languages.
-        description (str): The description of the structure.
-        descriptions (dict[str, str]): A dictionary of descriptions in different languages.
-        dimensions (dict[str, list[Dimension]]): The dimensions of the structure.
-        attributes (dict[str, list[Attribute]]): The attributes of the structure.
+        links: A list of related links.
+        name: The name of the structure.
+        names: A dictionary of names in different languages.
+        description: The description of the structure.
+        descriptions: A dictionary of descriptions in different languages.
+        dimensions: The dimensions of the structure.
+        attributes: The attributes of the structure.
     """
 
     links: list[Link]
@@ -159,8 +159,8 @@ class Series:
     """Represents a series within the dataset.
 
     Args:
-        attributes (list[int]): The attributes of the series.
-        observations (dict[str, list[str]]): The observations within the series.
+        attributes: The attributes of the series.
+        observations: The observations within the series.
     """
 
     attributes: list[int]
@@ -172,11 +172,11 @@ class DataSet:
     """Represents a dataset.
 
     Args:
-        links (list[Link]): A list of related links.
-        reportingBegin (str): The start date of the reporting period.
-        reportingEnd (str): The end date of the reporting period.
-        action (str): The action associated with the dataset.
-        series (dict[str, Series]): The series within the dataset.
+        links: A list of related links.
+        reportingBegin: The start date of the reporting period.
+        reportingEnd: The end date of the reporting period.
+        action: The action associated with the dataset.
+        series: The series within the dataset.
     """
 
     links: list[Link]
@@ -191,8 +191,8 @@ class Data:
     """Represents the data part of the dataset.
 
     Args:
-        dataSets (list[DataSet]): A list of datasets.
-        structure (Structure): The structure of the dataset.
+        dataSets: A list of datasets.
+        structure: The structure of the dataset.
     """
 
     dataSets: list[DataSet]
@@ -204,9 +204,9 @@ class ValutaData:
     """Represents the entire dataset including metadata and data.
 
     Args:
-        meta (ValutaMeta): The metadata of the dataset.
-        data (Data): The data part of the dataset.
-        df (pd.DataFrame | None): A DataFrame representation of the dataset (optional).
+        meta: The metadata of the dataset.
+        data: The data part of the dataset.
+        df: A DataFrame representation of the dataset (optional).
     """
 
     meta: ValutaMeta
@@ -225,7 +225,7 @@ def parse_structure(structure: dict[str, Any]) -> Structure:
     """Parse the structure section from data.
 
     Args:
-        structure (dict[str, Any]): Data containing the structure information.
+        structure: Data containing the structure information.
 
     Returns:
         Structure: An instance of the Structure dataclass.
@@ -253,7 +253,7 @@ def parse_datasets(datasets_data: list[dict[str, Any]]) -> list[DataSet]:
     """Parse the datasets section from data.
 
     Args:
-        datasets_data (list[dict[str, Any]]): Data containing datasets information.
+        datasets_data: Data containing datasets information.
 
     Returns:
         list[DataSet]: A list of DataSet dataclass instances.
@@ -281,8 +281,8 @@ def create_dataframe(data_obj: Data, structure_obj: Structure) -> pd.DataFrame:
     """Create a DataFrame from data and structure objects.
 
     Args:
-        data_obj (Data): The data object containing datasets.
-        structure_obj (Structure): The structure object containing dimensions and attributes.
+        data_obj: The data object containing datasets.
+        structure_obj: The structure object containing dimensions and attributes.
 
     Returns:
         pd.DataFrame: A pandas DataFrame created from the data and structure objects.
@@ -368,7 +368,7 @@ def parse_response(json_data: dict[str, Any]) -> ValutaData:
     """Convert the json response to a ValutaData object with nested dataclasses.
 
     Args:
-        json_data (dict[str, Any]): The response from the Norske Bank API.
+        json_data: The response from the Norske Bank API.
 
     Returns:
         ValutaData: An instance of the dataclass ValutaData.
@@ -417,16 +417,16 @@ def download_exchange_rates(
     See https://app.norges-bank.no/query/index.html#/no/
 
     Args:
-        currency (str): Specified in UPPER case letters. For multiple currencies, use a
+        currency: Specified in UPPER case letters. For multiple currencies, use a
             plus sign (e.g., 'GBP+EUR+USD'). No value gives all currencies.
-        frequency (str): Can be B (Business, daily rates), M (monthly rates),
+        frequency: Can be B (Business, daily rates), M (monthly rates),
             A (annual rates). For multiple frequencies, use a plus sign
             (e.g., 'A+M'). No value gives all frequencies. For annual rates,
             the time interval must cover a full year, similarly for months.
-        date_from (str): Specified in the format YYYY-MM-DD.
-        date_to (str | None): Specified in the format YYYY-MM-DD. If None, defaults to today's date.
-        language (str): 'no' for Norwegian, 'en' for English.
-        detail (str): 'full' gives both data and attributes, 'dataonly' gives only data,
+        date_from: Specified in the format YYYY-MM-DD.
+        date_to: Specified in the format YYYY-MM-DD. If None, defaults to today's date.
+        language: 'no' for Norwegian, 'en' for English.
+        detail: 'full' gives both data and attributes, 'dataonly' gives only data,
             'serieskeysonly' gives series without data or attributes,
             'nodata' gives series and attributes without data.
 

--- a/src/fagfunksjoner/dapla/standards/time.py
+++ b/src/fagfunksjoner/dapla/standards/time.py
@@ -24,7 +24,7 @@ def date_time(date: dt.datetime | None = None) -> str:
     See: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
 
     Args:
-        date (dt.datetime | None): A specified datetime you want to convert to string format.
+        date: A specified datetime you want to convert to string format.
             If not specified, it will give the datetime right now.
 
     Returns:
@@ -48,7 +48,7 @@ def date(date: dt.date | None = None) -> str:
     """Get date with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -63,7 +63,7 @@ def month(date: dt.date | None = None) -> str:
     """Get month period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -78,7 +78,7 @@ def year(date: dt.date | None = None) -> str:
     """Get year period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -93,7 +93,7 @@ def week(date: dt.date | None = None) -> str:
     """Get week period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -108,7 +108,7 @@ def year_days(date: dt.date | None = None) -> str:
     """Gives day of year period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -123,7 +123,7 @@ def quarterly(date: dt.date | None = None) -> str:
     """Get quarter period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -138,7 +138,7 @@ def bimester(date: dt.date | None = None) -> str:
     """Get bimester period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -162,7 +162,7 @@ def triannual(date: dt.date | None = None) -> str:
     """Gives triannual period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -179,7 +179,7 @@ def halfyear(date: dt.date | None = None) -> str:
     """Get halfyear period with standard format.
 
     Args:
-        date (dt.date | None): A specified date you want to convert to string format.
+        date: A specified date you want to convert to string format.
             If not specified, it will give the date today.
 
     Returns:
@@ -199,10 +199,10 @@ def _find_period(period_dict: dict[str, list[int]], month: int) -> str:
     represent a month between 1 and 12.
 
     Args:
-        period_dict (dict[str, list[int]]): Dict with self-made period standard.
+        period_dict: Dict with self-made period standard.
             The keys represent the self-made period,
             and the values are list of int that represent a month between 1 and 12.
-        month (int): Current month in number, between 1 and 12.
+        month: Current month in number, between 1 and 12.
 
     Returns:
         str: The self-made period, the key, fram the period_dict.

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -445,10 +445,10 @@ def handle_decimals(
 
     for col in desi_cols:
         # Look for comma as delimiter
-        if df[col].str.contains(",").any():
+        if df[col].str.contains(",", regex=False).any():
             df[col] = df[col].str.replace(",", ".").astype("Float64")
         # Look for punktum as delimiter
-        elif df[col].str.contains(".").any():
+        elif df[col].str.contains(".", regex=False).any():  # "." is a special character in regex, making this fail if regex is used.
             df[col] = df[col].str.replace(",", ".").astype("Float64")
         # If no delimiter is found, use number of decimals from metadata
         else:

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -448,7 +448,9 @@ def handle_decimals(
         if df[col].str.contains(",", regex=False).any():
             df[col] = df[col].str.replace(",", ".").astype("Float64")
         # Look for punktum as delimiter
-        elif df[col].str.contains(".", regex=False).any():  # "." is a special character in regex, making this fail if regex is used.
+        elif (
+            df[col].str.contains(".", regex=False).any()
+        ):  # "." is a special character in regex, making this fail if regex is used.
             df[col] = df[col].str.replace(",", ".").astype("Float64")
         # If no delimiter is found, use number of decimals from metadata
         else:
@@ -677,7 +679,7 @@ def get_path_combinations(
         dollar: str = path.split("/")[0].replace("$", "").replace("_PII", "").upper()
         non_dollar = stammer.get(dollar, None)
         if non_dollar is not None:
-            paths += [os.path.join(non_dollar, "/".join(path.split("/")[1:]))]
+            paths += ["/".join([non_dollar, "/".join(path.split("/")[1:])])]
     else:
         if not path.startswith("/"):
             path = "/" + path

--- a/src/fagfunksjoner/data/dicts.py
+++ b/src/fagfunksjoner/data/dicts.py
@@ -1,17 +1,22 @@
 """Extra functionality operating on baseline dicts added to this module."""
 
-from typing import Any
+from collections.abc import Hashable
+from typing import Any, TypeVar
 
 
-def get_key_by_value(data: dict[Any, Any], value: Any) -> Any | list[Any]:
+# Define a type variable that will match the type of the keys in the dictionary
+KeyType = TypeVar("KeyType", bound=Hashable)
+
+
+def get_key_by_value(data: dict[KeyType, Any], value: Any) -> KeyType | list[KeyType]:
     """Searches through the values in a dict for a match, returns the key.
 
     Args:
-        data (dict[Hashable, Any]): The data to search through, will only look in top most level...
+        data (dict[KeyType, Any]): The data to search through, will only look in top most level...
         value (Any): The value to look for in the dict
 
     Returns:
-        Hashable | list[Hashable]: Returns a single key if a single match on value,
+        KeyType | list[KeyType]: Returns a single key if a single match on value,
             otherwise returns a list of keys with the same value.
 
     Raises:

--- a/src/fagfunksjoner/data/dicts.py
+++ b/src/fagfunksjoner/data/dicts.py
@@ -12,8 +12,8 @@ def get_key_by_value(data: dict[KeyType, Any], value: Any) -> KeyType | list[Key
     """Searches through the values in a dict for a match, returns the key.
 
     Args:
-        data (dict[KeyType, Any]): The data to search through, will only look in top most level...
-        value (Any): The value to look for in the dict
+        data: The data to search through, will only look in top most level...
+        value: The value to look for in the dict
 
     Returns:
         KeyType | list[KeyType]: Returns a single key if a single match on value,

--- a/src/fagfunksjoner/data/pandas_combinations.py
+++ b/src/fagfunksjoner/data/pandas_combinations.py
@@ -29,14 +29,14 @@ def all_combos_agg(
     """Generate all aggregation levels for a set of columns in a dataframe.
 
     Args:
-        df (pd.DataFrame): dataframe to aggregate.
-        groupcols (list[str]): List of columns to group by.
-        aggargs (AggFuncTypeBase | AggFuncTypeDictSeries): how to aggregate, is sent to the agg function in pandas, look at its documentation.
-        fillna_dict (dict[str, str]): Fills "totals" in the groupcols, by filling their NA values.
+        df: dataframe to aggregate.
+        groupcols: List of columns to group by.
+        aggargs: how to aggregate, is sent to the agg function in pandas, look at its documentation.
+        fillna_dict: Fills "totals" in the groupcols, by filling their NA values.
             Send a dict with col names as keys, and string-values to put in cells as values.
-        keep_empty (bool): Keep groups without observations through the process.
+        keep_empty: Keep groups without observations through the process.
             Removing them is default behaviour of Pandas
-        grand_total (str | dict[str|str]): Fill this value, if you want a grand total in your aggregations.
+        grand_total: Fill this value, if you want a grand total in your aggregations.
             If you use a string, this will be input in the fields in the groupcol columns.
             If you send a dict, like to the fillna_dict parameter, the values in the cells in the grand_total will reflect the values in the dict.
 
@@ -94,9 +94,9 @@ def prepare_combinations(
     """Prepare the dataframe and generate all possible combinations of group columns.
 
     Args:
-        df (pd.DataFrame): The dataframe to process.
-        groupcols (list[str]): List of columns to group by.
-        keep_empty (bool): Whether to keep groups without observations.
+        df: The dataframe to process.
+        groupcols: List of columns to group by.
+        keep_empty: Whether to keep groups without observations.
 
     Returns:
         tuple[pd.DataFrame, list[tuple[str]]]: The prepared dataframe and list of group column combinations.
@@ -121,10 +121,10 @@ def calculate_aggregates(
     """Calculate aggregates for each combination of group columns.
 
     Args:
-        df (pd.DataFrame): The dataframe to aggregate.
-        combos (list[tuple[str]]): List of group column combinations.
-        aggargs (AggFuncTypeBase | AggFuncTypeDictSeries[str] | dict[str, list[str]]): Aggregation functions to apply.
-        keep_empty (bool): Whether to keep groups without observations.
+        df: The dataframe to aggregate.
+        combos: List of group column combinations.
+        aggargs: Aggregation functions to apply.
+        keep_empty: Whether to keep groups without observations.
 
     Returns:
         pd.DataFrame: The dataframe with calculated aggregates for each combination.
@@ -157,13 +157,13 @@ def finalize_dataframe(
     """Finalize the dataframe by calculating the grand total and filling missing values.
 
     Args:
-        all_levels (pd.DataFrame): The dataframe with calculated aggregates.
-        df (pd.DataFrame): The original dataframe.
-        groupcols (list[str]): List of columns to group by.
-        aggargs (AggFuncTypeBase | AggFuncTypeDictSeries[str] | dict[str, list[str]]): Aggregation functions to apply.
-        grand_total (dict[str, str] | str): Value(s) to use for the grand total row.
-        fillna_dict (dict[str, Any] | None): Values to fill in missing data.
-        keep_empty (bool): Whether to keep groups without observations.
+        all_levels: The dataframe with calculated aggregates.
+        df: The original dataframe.
+        groupcols: List of columns to group by.
+        aggargs: Aggregation functions to apply.
+        grand_total: Value(s) to use for the grand total row.
+        fillna_dict: Values to fill in missing data.
+        keep_empty: Whether to keep groups without observations.
 
     Returns:
         pd.DataFrame: The finalized dataframe.
@@ -212,8 +212,8 @@ def fill_na_dict(df: pd.DataFrame, mapping: dict[str, Any]) -> pd.DataFrame:
     Also handles categorical columns if they exist in the dataframe.
 
     Args:
-        df (pd.DataFrame): The DataFrame to fill NAs on.
-        mapping (dict): What each of the columns should have their NAs filled with.
+        df: The DataFrame to fill NAs on.
+        mapping: What each of the columns should have their NAs filled with.
 
     Returns:
         pd.DataFrame: The DataFrame with filled NAs.
@@ -232,8 +232,8 @@ def flatten_col_multiindex(df: pd.DataFrame, sep: str = "_") -> pd.DataFrame:
     Flattens it by combining the names of the multiindex, using the seperator (sep).
 
     Args:
-        df (pd.DataFrame): The DataFrame with multiindexed columns.
-        sep (str): What should seperate the names of the levels in the multiindex. Defaults to "_".
+        df: The DataFrame with multiindexed columns.
+        sep: What should seperate the names of the levels in the multiindex. Defaults to "_".
 
     Returns:
         pd.DataFrame: The DataFrame with the flattened column headers.

--- a/src/fagfunksjoner/data/pandas_dtypes.py
+++ b/src/fagfunksjoner/data/pandas_dtypes.py
@@ -17,8 +17,8 @@ def dtype_set_from_json(df: pd.DataFrame, json_path: str) -> pd.DataFrame:
     """Use a stored json to change the dtypes of a dataframe to match what was stored.
 
     Args:
-        df (pd.DataFrame): The Dataframe to manipulate towards the stored dtypes.
-        json_path (str): The jsonfile containing the dtypes on the columns.
+        df: The Dataframe to manipulate towards the stored dtypes.
+        json_path: The jsonfile containing the dtypes on the columns.
 
     Returns:
         pd.DataFrame: The manipulated dataframe, with newly set dtypes.
@@ -36,8 +36,8 @@ def dtype_store_json(df: pd.DataFrame, json_path: str) -> None:
     """Store the dtypes of a dataframes columns as a json for later reference.
 
     Args:
-        df (pd.DataFrame): The dataframe to look at for column names and dtypes.
-        json_path (str): The path to the jsonfile, to store dtypes in.
+        df: The dataframe to look at for column names and dtypes.
+        json_path: The path to the jsonfile, to store dtypes in.
     """
     dtype_metadata = {}
     for col, dtype in df.dtypes.items():
@@ -70,11 +70,11 @@ def auto_dtype(
     if number of unique values in the columns are below the threshold.
 
     Args:
-        df (pd.DataFrame): The dataframe to manipulate
-        cardinality_threshold (int): Less unique values in columns than this threshold,
+        df: The dataframe to manipulate
+        cardinality_threshold: Less unique values in columns than this threshold,
             means it should be converted to a categorical. Defaults to 0, meaning no conversion to categoricals.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
-        show_memory (bool): Show the user how much memory was saved by doing the conversion, does require some processing. Defaults to True.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        show_memory: Show the user how much memory was saved by doing the conversion, does require some processing. Defaults to True.
 
     Returns:
         pd.DataFrame: _description_
@@ -117,9 +117,9 @@ def decode_bytes(
     """Check object columns if they contain bytes and should be attempted to convert to real utf8 strings.
 
     Args:
-        df (pd.DataFrame): The dataframe to check.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
-        check_row_len (int): How many rows to look for byte-content in, conserves processing, but might miss columns if set too low. Defaults to 50.
+        df: The dataframe to check.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        check_row_len: How many rows to look for byte-content in, conserves processing, but might miss columns if set too low. Defaults to 50.
 
     Returns:
         pd.DataFrame: The dataframe with converted byte-columns to string-columns.
@@ -158,8 +158,8 @@ def object_to_strings(df: pd.DataFrame, copy_df: bool = True) -> pd.DataFrame:
     """Convert columns that are still "object", to pyarrow strings.
 
     Args:
-        df (pd.DataFrame): The dataframe to manipulate.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        df: The dataframe to manipulate.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
 
     Returns:
         pd.DataFrame: The modified dataframe.
@@ -178,8 +178,8 @@ def strings_to_int(df: pd.DataFrame, copy_df: bool = True) -> pd.DataFrame:
     This conserves A LOT of storage and memory.
 
     Args:
-        df (pd.DataFrame): The dataframe to manipulate.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        df: The dataframe to manipulate.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
 
     Returns:
         pd.DataFrame: The manipulated dataframe.
@@ -203,8 +203,8 @@ def smaller_ints(df: pd.DataFrame, copy_df: bool = True) -> pd.DataFrame:
     """Downcasts ints to smaller int-dtypes to conserve space.
 
     Args:
-        df (pd.DataFrame): The dataframe to manipulate.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        df: The dataframe to manipulate.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
 
     Returns:
         pd.DataFrame: The manipulated dataframe.
@@ -222,10 +222,10 @@ def categories_threshold(
     """Convert to categoricals using a threshold of unique values.
 
     Args:
-        df (pd.DataFrame): The dataframe to convert to categoricals on.
-        cardinality_threshold (int): Less unique values in columns than this threshold,
+        df: The dataframe to convert to categoricals on.
+        cardinality_threshold: Less unique values in columns than this threshold,
             means it should be converted to a categorical. Defaults to 0, meaning no conversion to categoricals.
-        copy_df (bool): The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
+        copy_df: The reverse of inplace, make a copy in memory. This may give a memory impact, but be safer. Defaults to True.
 
     Returns:
         pd.DataFrame: The dataframe with converted columns to categoricals.

--- a/src/fagfunksjoner/data/pyarrow.py
+++ b/src/fagfunksjoner/data/pyarrow.py
@@ -5,8 +5,8 @@ def cast_pyarrow_table_schema(data: pa.Table, schema: pa.Schema) -> pa.Table:
     """Set correct schema on Pyarrow Table, especially when dictionary datatype is wanted.
 
     Args:
-        data (pa.Table): The pyarrow table data
-        schema (pa.schema): The wanted schema to cast to the table data.
+        data: The pyarrow table data
+        schema: The wanted schema to cast to the table data.
             All columns in pyarrow table must be present in the schema.
             The order of the columns in the schema will be used.
 
@@ -38,8 +38,8 @@ def restructur_pyarrow_schema(
     this new schema.
 
     Args:
-        inuse_schema (pa.Schema): The schema that is in use of your pyarrow dataset or table.
-        wanted_schema (pa.Schema): The schema that you want, but it is not in the same order of
+        inuse_schema: The schema that is in use of your pyarrow dataset or table.
+        wanted_schema: The schema that you want, but it is not in the same order of
             the schema that is in use.
 
     Returns:

--- a/src/fagfunksjoner/data/view_dataframe.py
+++ b/src/fagfunksjoner/data/view_dataframe.py
@@ -14,10 +14,10 @@ def filter_display(
     """Filter data based on args, and display the result.
 
     Args:
-        dataframe (pd.DataFrame): The DataFrame to filter.
-        column (str): Column to base filter on.
-        value (str | int | float):The value to compare filter against.
-        operator (str): How to compare column against value.
+        dataframe: The DataFrame to filter.
+        column: Column to base filter on.
+        value:The value to compare filter against.
+        operator: How to compare column against value.
 
     Returns:
         None: only has visual side-effects
@@ -64,12 +64,12 @@ def view_dataframe(
     """Display an interactive widget for filtering and viewing data in a DataFrame based on selection of values in one column.
 
     Args:
-        dataframe (pd.DataFrame): The DataFrame containing the data to be filtered.
-        column (str): The column in the DataFrame to be filtered.
-        operator (str): The comparison operator for filtering (may be altered during the display).
+        dataframe: The DataFrame containing the data to be filtered.
+        column: The column in the DataFrame to be filtered.
+        operator: The comparison operator for filtering (may be altered during the display).
             Options: '==', '!=', '>=', '>', '<', '<='.
             Default: '=='.
-        unique_limit (int): The maximum number of unique values in the column
+        unique_limit: The maximum number of unique values in the column
             for using '==' or '!=' operators.
             Default: 100.
 

--- a/src/fagfunksjoner/paths/project_root.py
+++ b/src/fagfunksjoner/paths/project_root.py
@@ -64,7 +64,7 @@ class ProjectRoot:
         Looks in the current folder, the specified path, the project root.
 
         Args:
-            config_file (str): The path or filename of the config-file to load.
+            config_file: The path or filename of the config-file to load.
 
         Returns:
             dict[Any]: The contents of the toml-file.
@@ -131,7 +131,7 @@ def load_toml(config_file: str) -> dict[Any, Any]:
     Looks in the current folder, the specified path, the project root.
 
     Args:
-        config_file (str): The path or filename of the config-file to load.
+        config_file: The path or filename of the config-file to load.
 
     Returns:
         dict[Any]: The contents of the toml-file

--- a/src/fagfunksjoner/paths/versions.py
+++ b/src/fagfunksjoner/paths/versions.py
@@ -21,7 +21,7 @@ def get_latest_fileversions(glob_list_path: list[str]) -> list[str]:
     - Locally: https://docs.python.org/3/library/glob.html
 
     Args:
-        glob_list_path (list[str]): List of strings that represents a filepath.
+        glob_list_path: List of strings that represents a filepath.
             Recommend that the list is created with glob operation.
 
     Returns:
@@ -47,7 +47,7 @@ def latest_version_number(filepath: str) -> int:
     """Function for finding latest version in use for a file.
 
     Args:
-        filepath (str): GCS filepath or local filepath, should be the full path, but needs to follow the naming standard.
+        filepath: GCS filepath or local filepath, should be the full path, but needs to follow the naming standard.
             eg. ssb-prod-ofi-skatteregn-data-produkt/skatteregn/inndata/skd_data/2023/skd_p2023-01_v1.parquet
             or /ssb/stammeXX/kortkode/inndata/skd_data/2023/skd_p2023-01_v1.parquet
 
@@ -91,7 +91,7 @@ def next_version_number(filepath: str) -> int:
     """Function for finding next version for a new file.
 
     Args:
-        filepath (str): GCS filepath or local filepath, should be the full path, but needs to follow the naming standard.
+        filepath: GCS filepath or local filepath, should be the full path, but needs to follow the naming standard.
             eg. ssb-prod-ofi-skatteregn-data-produkt/skatteregn/inndata/skd_data/2023/skd_p2023-01_v1.parquet
             or /ssb/stammeXX/kortkode/inndata/skd_data/2023/skd_p2023-01_v1.parquet
 
@@ -111,7 +111,7 @@ def next_version_path(filepath: str) -> str:
     It increments the version number by one, to ensure the new file path is unique.
 
     Args:
-        filepath (str): The address for the file.
+        filepath: The address for the file.
 
     Returns:
         str: The new file path with an incremented version number and specified suffix.
@@ -131,7 +131,7 @@ def split_path(filepath: str) -> tuple[str, str, str]:
     """Split the filepath into three pieces, version, file-extension and the rest.
 
     Args:
-        filepath (str): The path you want split into pieces.
+        filepath: The path you want split into pieces.
 
     Raises:
         ValueError: If the version-part doesnt follow the naming standard.

--- a/src/fagfunksjoner/prodsone/check_env.py
+++ b/src/fagfunksjoner/prodsone/check_env.py
@@ -36,7 +36,7 @@ def linux_shortcuts(insert_environ: bool = False) -> dict[str, str]:
     If the function can find the file they are shared in.
 
     Args:
-        insert_environ (bool): Set to True if you want the dict to be inserted into the
+        insert_environ: Set to True if you want the dict to be inserted into the
             environment variables (os.environ).
 
     Returns:

--- a/src/fagfunksjoner/prodsone/dynarev.py
+++ b/src/fagfunksjoner/prodsone/dynarev.py
@@ -14,7 +14,7 @@ def dynarev_uttrekk(
 
     Args:
         delreg_nr: Delregisternummer.
-        skjema Skjemanavn.
+        skjema: Skjemanavn.
         dublettsjekk: If True, checks for and returns duplicates.
         sfu_cols: Specify a list of columns for SFU data, or a single column as a string.
             If True picks all columns. If None, skips getting sfu-data.

--- a/src/fagfunksjoner/prodsone/dynarev.py
+++ b/src/fagfunksjoner/prodsone/dynarev.py
@@ -13,10 +13,10 @@ def dynarev_uttrekk(
     """Fetches and processes data from the Oracle database using the Oracle class for connection management.
 
     Args:
-        delreg_nr (str): Delregisternummer.
-        skjema (str): Skjemanavn.
-        dublettsjekk (bool) : If True, checks for and returns duplicates.
-        sfu_cols (list[str | str. | bool | None) : Specify a list of columns for SFU data, or a single column as a string.
+        delreg_nr: Delregisternummer.
+        skjema Skjemanavn.
+        dublettsjekk: If True, checks for and returns duplicates.
+        sfu_cols: Specify a list of columns for SFU data, or a single column as a string.
             If True picks all columns. If None, skips getting sfu-data.
 
     Returns:

--- a/src/fagfunksjoner/prodsone/oradb.py
+++ b/src/fagfunksjoner/prodsone/oradb.py
@@ -58,7 +58,7 @@ class Oracle:
         If it is too much data, then use the select_many method.
 
         Args:
-            sql (str): the SQL query statement
+            sql: the SQL query statement
 
         Returns:
             list[dict[str, Any]]: A list of dictionaries of every record, column names as keys.
@@ -93,8 +93,8 @@ class Oracle:
         correct order to each other.
 
         Args:
-            sql (str): SQL query statement, insert or update.
-            update (list[tuple[Any, ...]]): list of record values to insert or update.
+            sql: SQL query statement, insert or update.
+            update: list of record values to insert or update.
 
         Raises:
             error: If the connection returns an error.
@@ -123,8 +123,8 @@ class Oracle:
         which is preferred when there is a lot of data that needs to be fetched.
 
         Args:
-            sql (str): the SQL query statement.
-            batchsize (int): the size of rows per batch.
+            sql: the SQL query statement.
+            batchsize: the size of rows per batch.
 
         Returns:
             list[dict[str, Any]]: A list of dictionaries of every record, column names as keys.

--- a/src/fagfunksjoner/prodsone/saspy_ssb.py
+++ b/src/fagfunksjoner/prodsone/saspy_ssb.py
@@ -260,7 +260,7 @@ def set_libref(
     Returns:
         tuple[str, str]: the librefname and the filename
     """
-    librefpath, librefname, filename = split_path_for_sas(Path(path))
+    librefpath, _librefname, filename = split_path_for_sas(Path(path))
     _ = sas.saslib(librefname, path=librefpath)
     return librefname, filename
 

--- a/src/fagfunksjoner/prodsone/saspy_ssb.py
+++ b/src/fagfunksjoner/prodsone/saspy_ssb.py
@@ -66,7 +66,7 @@ def set_password(password: str) -> None:
     Send this as the parameter into this function.
 
     Args:
-        password (str): Your password encrypted using SAS EG
+        password: Your password encrypted using SAS EG
     """
     brukernavn = getpass.getuser()
     authpath = "/ssb/bruker/" + brukernavn + "/.authinfo"
@@ -102,7 +102,7 @@ def swap_server(new_server: int) -> None:
     """Swap between the sas-servers you connect to with saspy.
 
     Args:
-        new_server (int): The server number to switch to.
+        new_server: The server number to switch to.
     """
     felles = os.environ["FELLES"]
     brukernavn = getpass.getuser()
@@ -140,7 +140,7 @@ def split_path_for_sas(path: Path) -> tuple[str, str, str]:
     """Split a path in three parts, mainly for having a name for the libname.
 
     Args:
-        path (Path): The full path to be split
+        path: The full path to be split
 
     Returns:
         tuple[str]: The three parts the path has been split into.
@@ -158,7 +158,7 @@ def saspy_df_from_path(path: str) -> pd.DataFrame:
     terminates the connection to saspy cleanly, and returns the dataframe.
 
     Args:
-        path (str): The full path to the sasfile you want to open with sas.
+        path: The full path to the sasfile you want to open with sas.
 
     Returns:
         pandas.DataFrame: The raw content of the sasfile straight from saspy
@@ -183,9 +183,9 @@ def sasfile_to_parquet(
     """Convert a sasfile directly to a parquetfile, using saspy and pandas.
 
     Args:
-        path_str (str): The path to the in-sas-file.
-        out_path_str (str): The path to place the parquet-file on
-        gzip (bool): If you want the parquetfile gzipped or not.
+        path_str: The path to the in-sas-file.
+        out_path_str: The path to place the parquet-file on
+        gzip: If you want the parquetfile gzipped or not.
 
     Returns:
         pandas.DataFrame: In case you want to use the content for something else.
@@ -217,8 +217,8 @@ def cp(from_path: str, to_path: str) -> dict[str, Any]:
     """Use saspy and sas-server to copy files.
 
     Args:
-        from_path (str): The path for the source file to copy
-        to_path (str): The path to place the copy on
+        from_path: The path for the source file to copy
+        to_path: The path to place the copy on
 
     Returns:
         dict[str, Any]: A key for if it succeded, and a key for holding the log as string.

--- a/src/fagfunksjoner/prodsone/saspy_ssb.py
+++ b/src/fagfunksjoner/prodsone/saspy_ssb.py
@@ -183,7 +183,7 @@ def df_from_sasfile(path: str) -> pd.DataFrame:
     try:
         df: pd.DataFrame = sas.sasdata2dataframe(filename, libref=librefname)
     except Exception as e:
-        logger.error(e)
+        logger.error(str(e))
     finally:
         # sas.disconnect()
         sas._endsas()
@@ -216,11 +216,11 @@ def sasfile_to_parquet(
         )  # Avoid extra file extensions
     if gzip:
         out_path = out_path.with_suffix(".parquet.gzip")
-        logger.info(path, out_path)
+        logger.info("in-path: %s out-path: %s",path, out_path)
         df.to_parquet(out_path, compression="gzip")
     else:
         out_path = out_path.with_suffix(".parquet")
-        logger.info(path, out_path)
+        logger.info("in-path: %s out-path: %s", path, out_path)
         df.to_parquet(out_path)
     logger.info(f"Outputted to {out_path}")
     return df
@@ -241,7 +241,7 @@ def df_to_sasfile(df: pd.DataFrame, outpath: str) -> str:
         librefname, filename = set_libref(outpath, sas)
         sas.df2sd(df, filename, libref=librefname)
     except Exception as e:
-        logger.error(e)
+        logger.error(str(e))
     finally:
         sas._endsas()
     return outpath

--- a/src/fagfunksjoner/prodsone/saspy_ssb.py
+++ b/src/fagfunksjoner/prodsone/saspy_ssb.py
@@ -216,7 +216,7 @@ def sasfile_to_parquet(
         )  # Avoid extra file extensions
     if gzip:
         out_path = out_path.with_suffix(".parquet.gzip")
-        logger.info("in-path: %s out-path: %s",path, out_path)
+        logger.info("in-path: %s out-path: %s", path, out_path)
         df.to_parquet(out_path, compression="gzip")
     else:
         out_path = out_path.with_suffix(".parquet")

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -1,0 +1,409 @@
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+import xml.etree.ElementTree as ET
+from datetime import datetime
+import pandas as pd
+
+from fagfunksjoner.data import datadok_extract
+
+
+def test_is_valid_url():
+    assert datadok_extract.is_valid_url("http://example.com") is True
+    assert datadok_extract.is_valid_url("https://example.com") is True
+    assert datadok_extract.is_valid_url("ftp://example.com") is True
+    assert datadok_extract.is_valid_url("invalid-url") is False
+    assert datadok_extract.is_valid_url("http://") is False
+    assert datadok_extract.is_valid_url("") is False
+
+def test_extract_context_variables():
+    xml_data = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
+        <meta:ContactInformation>
+            <common:Division>Test Division</common:Division>
+        </meta:ContactInformation>
+        <meta:ContextVariable id="1">
+            <meta:Title>Variable Title</meta:Title>
+            <meta:Description>Variable Description</meta:Description>
+            <meta:Properties>
+                <meta:Datatype>Tekst</meta:Datatype>
+                <meta:Length>10</meta:Length>
+                <meta:StartPosition>1</meta:StartPosition>
+            </meta:Properties>
+        </meta:ContextVariable>
+    </root>
+    """
+    root = ET.fromstring(xml_data)
+    context_variables = datadok_extract.extract_context_variables(root)
+
+    assert len(context_variables) == 1
+    assert context_variables[0].context_id == "1"
+    assert context_variables[0].title == "Variable Title"
+    assert context_variables[0].description == "Variable Description"
+    assert context_variables[0].datatype == "Tekst"
+    assert context_variables[0].length == 10
+    assert context_variables[0].start_position == 1
+    assert context_variables[0].division == "Test Division"
+
+
+def test_codelist_to_df():
+    codelist = [
+        datadok_extract.CodeList(context_id="1", codelist_title="Title1", codelist_description="Desc1", code_value="001", code_text="Code Text 1"),
+        datadok_extract.CodeList(context_id="2", codelist_title="Title2", codelist_description="Desc2", code_value="002", code_text="Code Text 2"),
+    ]
+    
+    df = datadok_extract.codelist_to_df(codelist)
+    
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert df.iloc[0]["context_id"] == "1"
+    assert df.iloc[1]["code_value"] == "002"
+    assert df.iloc[0]["codelist_title"] == "Title1"
+
+
+def test_date_parser():
+    assert datadok_extract.date_parser("20240101", "%Y%m%d") == datetime(2024, 1, 1)
+    assert datadok_extract.date_parser("240101", "%y%m%d") == datetime(2024, 1, 1)
+    assert pd.isna(datadok_extract.date_parser("invalid-date", "%Y%m%d"))
+
+def test_codelist_to_dict():
+    # Test with non-empty DataFrame
+    data = {
+        "codelist_title": ["Title1", "Title1", "Title2"],
+        "code_value": ["001", "002", "003"],
+        "code_text": ["Text1", "Text2", "Text3"]
+    }
+    df = pd.DataFrame(data)
+    result = datadok_extract.codelist_to_dict(df)
+    
+    assert isinstance(result, dict)
+    assert "Title1" in result
+    assert result["Title1"]["001"] == "Text1"
+    assert result["Title2"]["003"] == "Text3"
+    
+    # Test with empty DataFrame
+    df_empty = pd.DataFrame(columns=["codelist_title", "code_value", "code_text"])
+    result_empty = datadok_extract.codelist_to_dict(df_empty)
+    
+    assert result_empty == {}
+
+def test_convert_dates():
+    data = {
+        "title": ["date_col1", "date_col2"],
+        "length": [8, 6],
+        "datatype": ["Dato1", "Dato2"],
+    }
+    metadata_df = pd.DataFrame(data)
+    
+    df_data = {
+        "date_col1": ["20240101", "20231231"],
+        "date_col2": ["010124", "311223"]
+    }
+    df = pd.DataFrame(df_data)
+    
+    df, metadata_df = datadok_extract.convert_dates(df, metadata_df)
+    
+    assert pd.api.types.is_datetime64_any_dtype(df["date_col1"])
+    assert pd.api.types.is_datetime64_any_dtype(df["date_col2"])
+
+
+def test_extract_codelist():
+    xml_data = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:codelist="http://www.ssb.no/ns/meta/codelist">
+        <meta:ContextVariable id="1">
+            <codelist:Codelist>
+                <codelist:CodelistMeta>
+                    <codelist:Title>Codelist Title 1</codelist:Title>
+                    <codelist:Description>Codelist Description 1</codelist:Description>
+                </codelist:CodelistMeta>
+                <codelist:Codes>
+                    <codelist:Code>
+                        <codelist:CodeValue>001</codelist:CodeValue>
+                        <codelist:CodeText>Code Text 1</codelist:CodeText>
+                    </codelist:Code>
+                    <codelist:Code>
+                        <codelist:CodeValue>002</codelist:CodeValue>
+                        <codelist:CodeText>Code Text 2</codelist:CodeText>
+                    </codelist:Code>
+                </codelist:Codes>
+            </codelist:Codelist>
+        </meta:ContextVariable>
+        <meta:ContextVariable id="2">
+            <codelist:Codelist>
+                <codelist:CodelistMeta>
+                    <codelist:Title>Codelist Title 2</codelist:Title>
+                    <codelist:Description>Codelist Description 2</codelist:Description>
+                </codelist:CodelistMeta>
+                <codelist:Codes>
+                    <codelist:Code>
+                        <codelist:CodeValue>003</codelist:CodeValue>
+                        <codelist:CodeText>Code Text 3</codelist:CodeText>
+                    </codelist:Code>
+                </codelist:Codes>
+            </codelist:Codelist>
+        </meta:ContextVariable>
+    </root>
+    """
+    root = ET.fromstring(xml_data)
+    codelist_data = datadok_extract.extract_codelist(root)
+
+    assert len(codelist_data) == 3
+    assert codelist_data[0].context_id == "1"
+    assert codelist_data[0].codelist_title == "Codelist Title 1"
+    assert codelist_data[0].codelist_description == "Codelist Description 1"
+    assert codelist_data[0].code_value == "001"
+    assert codelist_data[0].code_text == "Code Text 1"
+
+    assert codelist_data[2].context_id == "2"
+    assert codelist_data[2].codelist_title == "Codelist Title 2"
+    assert codelist_data[2].codelist_description == "Codelist Description 2"
+    assert codelist_data[2].code_value == "003"
+    assert codelist_data[2].code_text == "Code Text 3"
+
+def test_extract_codelist_missing_elements():
+    xml_data_missing = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:codelist="http://www.ssb.no/ns/meta/codelist">
+        <meta:ContextVariable id="1">
+            <codelist:Codelist>
+                <codelist:CodelistMeta>
+                    <!-- Missing title and description -->
+                </codelist:CodelistMeta>
+                <codelist:Codes>
+                    <codelist:Code>
+                        <!-- Missing code value and code text -->
+                    </codelist:Code>
+                </codelist:Codes>
+            </codelist:Codelist>
+        </meta:ContextVariable>
+    </root>
+    """
+    root = ET.fromstring(xml_data_missing)
+    codelist_data = datadok_extract.extract_codelist(root)
+
+    # Since the codelist is missing critical elements, the result should be empty
+    assert len(codelist_data) == 0
+
+
+
+def test_handle_decimals_with_comma():
+    # Test case with comma as the decimal separator
+    data = {
+        "col1": ["1,23", "4,56", "7,89"],
+        "col2": ["10,00", "20,50", "30,75"]
+    }
+    df = pd.DataFrame(data)
+    
+    metadata_data = {
+        "title": ["col1", "col2"],
+        "datatype": ["Desimaltall", "Desimaltall"],
+        "precision": [None, None]  # Precision not used in this case
+    }
+    metadata_df = pd.DataFrame(metadata_data)
+    
+    df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
+    
+    assert df["col1"].dtype == "Float64"
+    assert df["col2"].dtype == "Float64"
+    assert df["col1"].iloc[0] == 1.23
+    assert df["col2"].iloc[1] == 20.50
+    assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
+
+def test_handle_decimals_with_period():
+    # Test case with period as the decimal separator
+    data = {
+        "col1": ["1.23", "4.56", "7.89"],
+        "col2": ["10.00", "20.50", "30.75"]
+    }
+    df = pd.DataFrame(data)
+    
+    metadata_data = {
+        "title": ["col1", "col2"],
+        "datatype": ["Desimaltall", "Desimaltall"],
+        "precision": [None, None]  # Precision not used in this case
+    }
+    metadata_df = pd.DataFrame(metadata_data)
+    
+    df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
+    
+    assert df["col1"].dtype == "Float64"
+    assert df["col2"].dtype == "Float64"
+    assert df["col1"].iloc[0] == 1.23
+    assert df["col2"].iloc[1] == 20.50
+    assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
+
+def test_handle_decimals_with_no_separator():
+    # Test case with no separator and precision in metadata
+    data = {
+        "col1": ["123", "456", "789"],
+        "col2": ["1000", "2050", "3075"]
+    }
+    df = pd.DataFrame(data)
+    
+    metadata_data = {
+        "title": ["col1", "col2"],
+        "datatype": ["Desimaltall", "Desimaltall"],
+        "precision": [2, 2]  # Precision indicates 2 decimal places
+    }
+    metadata_df = pd.DataFrame(metadata_data)
+    
+    df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
+    
+    assert pd.api.types.is_float_dtype(df["col1"])
+    assert pd.api.types.is_float_dtype(df["col2"])
+    assert df["col1"].iloc[0] == 1.23  # 123 -> 1.23 based on precision
+    assert df["col2"].iloc[1] == 20.50  # 2050 -> 20.50 based on precision
+    assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
+
+def test_handle_decimals_with_empty_metadata():
+    # Test case with empty metadata DataFrame
+    data = {
+        "col1": ["1,23", "4,56", "7,89"]
+    }
+    df = pd.DataFrame(data)
+    
+    metadata_df = pd.DataFrame(columns=["title", "datatype", "precision"])
+    
+    df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
+    
+    # The dataframe should remain unchanged since no metadata information is provided
+    assert df["col1"].iloc[0] == "1,23"  # No change
+    assert df["col1"].dtype == "object"  # No type change
+
+
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+import pandas as pd
+import xml.etree.ElementTree as ET
+
+# Mocking the is_valid_url function to return True or False as needed
+@patch("requests.get")
+@patch("builtins.open", new_callable=mock_open, read_data="<root></root>")
+@patch("pandas.read_fwf")
+def test_import_archive_data_with_url(mock_read_fwf, mock_open, mock_requests_get):
+    # Mocking the XML response from the URL
+    mock_requests_get.return_value.text = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
+        <meta:ContactInformation>
+            <common:Division>Test Division</common:Division>
+        </meta:ContactInformation>
+        <meta:ContextVariable id="1">
+            <meta:Title>Variable Title</meta:Title>
+            <meta:Description>Variable Description</meta:Description>
+            <meta:Properties>
+                <meta:Datatype>Tekst</meta:Datatype>
+                <meta:Length>10</meta:Length>
+                <meta:StartPosition>1</meta:StartPosition>
+            </meta:Properties>
+        </meta:ContextVariable>
+    </root>
+    """
+
+    # Mocking the DataFrame returned by pd.read_fwf
+    mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    mock_read_fwf.return_value = mock_df
+
+    # Import the function from the module where it is defined
+    archive_data = datadok_extract.import_archive_data(
+        archive_desc_xml="http://example.com/mock.xml",
+        archive_file="mock_archive.txt"
+    )
+
+    # Check if requests.get was called
+    mock_requests_get.assert_called_once_with("http://example.com/mock.xml")
+
+    # Check if pd.read_fwf was called with the correct parameters
+    mock_read_fwf.assert_called_once()
+    assert isinstance(archive_data.df, pd.DataFrame)
+    assert archive_data.df.equals(mock_df)
+
+    # Ensure metadata DataFrame and codelist DataFrame are not empty
+    assert not archive_data.metadata_df.empty
+    assert archive_data.metadata_df["title"].iloc[0] == "Variable Title"
+
+@patch("requests.get")
+@patch("builtins.open", new_callable=mock_open, read_data="<root></root>")
+@patch("pandas.read_fwf")
+def test_import_archive_data_with_file(mock_read_fwf, mock_open, mock_requests_get):
+    # Simulate the file-based XML content with ContactInformation element
+    xml_content = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
+        <meta:ContactInformation>
+            <common:Division>Test Division</common:Division>
+        </meta:ContactInformation>
+        <meta:ContextVariable id="1">
+            <meta:Title>Variable Title</meta:Title>
+            <meta:Description>Variable Description</meta:Description>
+            <meta:Properties>
+                <meta:Datatype>Tekst</meta:Datatype>
+                <meta:Length>10</meta:Length>
+                <meta:StartPosition>1</meta:StartPosition>
+            </meta:Properties>
+        </meta:ContextVariable>
+    </root>
+    """
+    mock_open.return_value.read.return_value = xml_content
+
+    # Mocking the DataFrame returned by pd.read_fwf
+    mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    mock_read_fwf.return_value = mock_df
+
+    # Import the function from the module where it is defined
+    archive_data = datadok_extract.import_archive_data(
+        archive_desc_xml="mock.xml",
+        archive_file="mock_archive.txt"
+    )
+
+    # Check if the file was opened
+    mock_open.assert_called_once_with("mock.xml")
+
+    # Check if pd.read_fwf was called with the correct parameters
+    mock_read_fwf.assert_called_once()
+    assert isinstance(archive_data.df, pd.DataFrame)
+    assert archive_data.df.equals(mock_df)
+
+    # Ensure metadata DataFrame and codelist DataFrame are not empty
+    assert not archive_data.metadata_df.empty
+    assert archive_data.metadata_df["title"].iloc[0] == "Variable Title"
+
+@patch("requests.get")
+@patch("builtins.open", new_callable=mock_open, read_data="<root></root>")
+@patch("pandas.read_fwf")
+def test_import_archive_data_with_invalid_params(mock_read_fwf, mock_open, mock_requests_get):
+    # Simulate the file-based XML content with ContactInformation element
+    xml_content = """
+    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
+        <meta:ContactInformation>
+            <common:Division>Test Division</common:Division>
+        </meta:ContactInformation>
+        <meta:ContextVariable id="1">
+            <meta:Title>Variable Title</meta:Title>
+            <meta:Description>Variable Description</meta:Description>
+            <meta:Properties>
+                <meta:Datatype>Tekst</meta:Datatype>
+                <meta:Length>10</meta:Length>
+                <meta:StartPosition>1</meta:StartPosition>
+            </meta:Properties>
+        </meta:ContextVariable>
+    </root>
+    """
+    mock_open.return_value.read.return_value = xml_content
+
+    # Now, we expect a ValueError related to the dtype parameter
+    with pytest.raises(ValueError, match="You cannot pass dtype to pandas.fwf"):
+        datadok_extract.import_archive_data(
+            archive_desc_xml="mock.xml",
+            archive_file="mock_archive.txt",
+            dtype={"col1": "Int64"}  # Passing an invalid parameter that should be overridden
+        )
+
+def test_import_archive_data_parse_error():
+   # Test case when the XML cannot be parsed
+    invalid_xml_content = "<root><invalid></root>"
+
+    with patch("builtins.open", mock_open(read_data=invalid_xml_content)):
+        with pytest.raises(ET.ParseError):
+            datadok_extract.import_archive_data(
+                archive_desc_xml="mock.xml",
+                archive_file="mock_archive.txt"
+            )
+

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -1,3 +1,4 @@
+import math
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from unittest.mock import mock_open, patch
@@ -211,10 +212,10 @@ def test_handle_decimals_with_comma():
 
     df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
 
-    assert df["col1"].dtype == "Float64"
-    assert df["col2"].dtype == "Float64"
-    assert df["col1"].iloc[0] == 1.23
-    assert df["col2"].iloc[1] == 20.50
+    assert pd.api.types.is_float_dtype(df["col1"])
+    assert pd.api.types.is_float_dtype(df["col2"])
+    assert math.isclose(df["col1"].iloc[0], 1.23)
+    assert math.isclose(df["col2"].iloc[1], 20.50)
     assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
 
 
@@ -232,10 +233,10 @@ def test_handle_decimals_with_period():
 
     df, metadata_df = datadok_extract.handle_decimals(df, metadata_df)
 
-    assert df["col1"].dtype == "Float64"
+    assert pd.api.types.is_float_dtype(df["col1"])
     assert df["col2"].dtype == "Float64"
-    assert df["col1"].iloc[0] == 1.23
-    assert df["col2"].iloc[1] == 20.50
+    assert math.isclose(df["col1"].iloc[0], 1.23)
+    assert math.isclose(df["col2"].iloc[1], 20.50)
     assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
 
 
@@ -255,8 +256,8 @@ def test_handle_decimals_with_no_separator():
 
     assert pd.api.types.is_float_dtype(df["col1"])
     assert pd.api.types.is_float_dtype(df["col2"])
-    assert df["col1"].iloc[0] == 1.23  # 123 -> 1.23 based on precision
-    assert df["col2"].iloc[1] == 20.50  # 2050 -> 20.50 based on precision
+    assert math.isclose(df["col1"].iloc[0], 1.23)  # 123 -> 1.23 based on precision
+    assert math.isclose(df["col2"].iloc[1], 20.50)  # 2050 -> 20.50 based on precision
     assert metadata_df.loc[metadata_df["title"] == "col1", "type"].iloc[0] == "Float64"
 
 


### PR DESCRIPTION
Bumps version to 1.0.2

Main functionality added is 
- a broader search in datadok_extract to look for valid paths in the API and on disk. We are even trying to look BACK IN TIME to find possible matching entries in Datadok...
- Function in saspy for easily storing dataframes as sas7bdat-files
- Function in statistikkregisteret to raise an error on a missing future publishing (when we start work on a statistical product, the publishing should already have been reported in 3 months before the publishing date).

Other points:
- Removed duplicate type hints for Args in the docstrings.
- Trying to work on suggestions from Sonarcloud.

![image](https://github.com/user-attachments/assets/8799830f-7bf4-4236-a19b-640e550044b8)
![image](https://github.com/user-attachments/assets/64b1a1a0-d99c-486d-98c7-6cc072e61c8c)

