### PR TITLE
Fredrick wishes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-fagfunksjoner"
-version = "1.0.2"
+version = "1.0.3"
 description = "Fellesfunksjoner for ssb i Python"
 authors = ["SSB-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -31,7 +31,7 @@ class PublishingSpecifics:
     """Hold specific information about each publishing."""
 
     name: str
-    stat_id: str
+    publish_id: str
     statistic: str
     variant: str
     status: str
@@ -384,7 +384,7 @@ def kwargs_specifics(nested: dict[str, Any]) -> dict[str, Any]:
     """
     return {
         "name": nested["publisering"]["navn"],
-        "stat_id": nested["publisering"]["@id"],
+        "publish_id": nested["publisering"]["@id"],
         "statistic": nested["publisering"]["@statistikk"],
         "variant": nested["publisering"]["@variant"],
         "status": STATUS_MAP.get(
@@ -616,10 +616,10 @@ def time_until_publishing(shortname: str = "trosamf") -> datetime.timedelta | No
     if (
         isinstance(pub, StatisticPublishingShort)
         and pub.specifics is not None
-        and hasattr(pub.specifics, "tidspunkt")
+        and hasattr(pub.specifics, "time")
     ):
 
-        pub_time: datetime.datetime = pub.specifics.tidspunkt
+        pub_time: datetime.datetime = pub.specifics.time
         diff_time: datetime.timedelta = pub_time - datetime.datetime.now()
         return diff_time
     return None
@@ -643,9 +643,9 @@ def find_latest_publishing(
         if (
             isinstance(pub, StatisticPublishingShort)
             and pub.specifics is not None
-            and hasattr(pub.specifics, "tidspunkt")
+            and hasattr(pub.specifics, "time")
         ):
-            current_date = pub.specifics.tidspunkt
+            current_date = pub.specifics.time
             if current_date > max_date:
                 max_publ = (
                     pub  # Overwrites variable with the whole StatisticPublishingShort
@@ -750,7 +750,7 @@ def sections_publishings(
         content = [
             stat
             for stat in content
-            if stat.status not in [STATUS_MAP["IA"], STATUS_MAP["UT"]]
+            if stat.status not in [STATUS_MAP["IA"], STATUS_MAP["UT"], STATUS_MAP["SA"]]
         ]
     if get_publishings:
         for i, stat in enumerate(content):

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -20,33 +20,32 @@ DESKFLYT = "@deskFlyt"
 class PublishingSpecifics:
     """Hold specific information about each publishing."""
 
-    navn: str
-    statid: str
-    statistikk: str
+    name: str
+    stat_id: str
+    statistic: str
     variant: str
     status: str
-    er_periode: bool
-    periode_fra: datetime.datetime
-    periode_til: datetime.datetime
-    presisjon: str
-    tidspunkt: datetime.datetime
-    er_endret: bool
-    desk_flyt: str
-    endret: datetime.datetime
-    er_avlyst: bool
-    revisjon: str
-    tittel: str
+    is_period: bool
+    period_from: datetime.datetime
+    period_until: datetime.datetime
+    precision: str
+    time: datetime.datetime
+    has_changed: bool
+    desk_flow: str
+    time_changed: datetime.datetime
+    is_cancelled: bool
+    revision: str
+    title: str
 
 
 @dataclass
 class StatisticPublishingShort:
     """Top-level metadata for a specific statistical product."""
 
-    statid: str
+    stat_id: str
     variant: str
-    desk_flyt: str
-    endret: datetime.datetime
-    statistikk_kortnavn: str
+    desk_flow: str
+    time_changed: datetime.datetime
     specifics: None | PublishingSpecifics
 
 
@@ -54,9 +53,9 @@ class StatisticPublishingShort:
 class MultiplePublishings:
     """Contains multiple statisticss, like when getting all the data in the API."""
 
-    publiseringer: list[StatisticPublishingShort]
-    antall: int
-    dato: str
+    publishings: list[StatisticPublishingShort]
+    amount: int
+    date: str
 
 
 @dataclass
@@ -66,58 +65,58 @@ class LangText:
     Attributes:
         lang: The language code.
         text: The text in the specified language.
-        navn: Unused attribute, kept for compatibility.
+        name: Unused attribute, kept for compatibility.
     """
 
     lang: str
     text: None | str
-    navn: None
+    name: None
 
 
 @dataclass
-class Navn:
+class Name:
     """Represents a list of LangText objects.
 
     Attributes:
-        navn_lang: A list of LangText objects.
+        name_lang: A list of LangText objects.
     """
 
-    navn_lang: list[LangText]
+    name_lang: list[LangText]
 
 
 @dataclass
-class Kontakt:
+class Contact:
     """Represents a contact with various attributes.
 
     Attributes:
-        navn: A list of LangText objects representing names.
-        statid: The contact ID.
-        telefon: The contact's phone number.
-        mobil: The contact's mobile number.
-        epost: The contact's email address.
-        initialer: The contact's initials.
+        name: A list of LangText objects representing names.
+        contact_id: The contact ID.
+        phone: The contact's phone number.
+        cellphone: The contact's cellphonee number.
+        email: The contact's email address.
+        initials: The contact's initials.
     """
 
-    navn: list[LangText]
-    statid: str
-    telefon: str
-    mobil: str
-    epost: str
-    initialer: str
+    name: Name
+    contact_id: str
+    phone: str
+    cellphone: str
+    email: str
+    initials: str
+    changed: str | datetime.datetime | None
 
 
 @dataclass
-class Eierseksjon:
+class Owningsection:
     """Represents an ownership section with various attributes.
 
     Attributes:
-        navn: A list of LangText objects representing names.
-        statid: The section ID.
-        navn_attr: The section name.
+        name: A list of LangText objects representing names.
+        section_id: The section ID.
     """
 
-    navn: list[LangText]
-    statid: str
+    name: list[LangText]
+    section_id: str
 
 
 @dataclass
@@ -125,22 +124,22 @@ class Variant:
     """Represents a variant with various attributes.
 
     Attributes:
-        navn: The name of the variant.
-        statid: The variant ID.
-        revisjon: The revision of the variant.
-        opphort: Whether the variant is discontinued.
-        detaljniva: Detailed level information.
-        detaljniva_EN: Detailed level information in English.
-        frekvens: The frequency of the variant.
+        name: The name of the variant.
+        variant_id: The variant ID.
+        revision: The revision of the variant.
+        ceased: Whether the variant is discontinued.
+        detail_level: Detailed level information.
+        detail_level_en: Detailed level information in English.
+        frequency: The frequency of the variant.
     """
 
-    navn: str
-    statid: str
-    revisjon: str
-    opphort: str
-    detaljniva: str
-    detaljniva_en: str
-    frekvens: str
+    name: str
+    variant_id: str
+    revision: str
+    ceased: str
+    detail_level: str
+    detail_level_en: str
+    frequency: str
 
 
 @dataclass
@@ -148,42 +147,47 @@ class SinglePublishing:
     """Represents a single publishing entry with various attributes.
 
     Attributes:
-        navn: The name details.
-        kortnavn: The short name.
-        gamleEmnekoder: The old subject codes.
-        forstegangspublisering: The first publication date.
+        name: The name details.
+        short_name: The short name.
+        old_subjectcodes: The old subject codes.
+        firstpubilishing: The first publication date.
         status: The status code.
-        eierseksjon: The ownership section details.
-        kontakter: A list of contacts.
-        triggerord: A dictionary of trigger words.
-        varianter: A list of variants.
-        regionaleNivaer: A list of regional levels.
-        videreforing: A dictionary of continuation information.
-        statid: The ID of the publishing entry.
-        defaultLang: The default language code.
-        godkjent: Approval status.
-        endret: The last modified date.
-        deskFlyt: Desk flow status.
-        dirFlyt: Directory flow status.
+        owner_name: The ownership section name.
+        owner_code: The ownership section code.
+        contacts: A list of contacts.
+        triggerwords: A dictionary of trigger words.
+        variants: A list of variants.
+        regional_levels: A list of regional levels.
+        continuation: A dictionary of continuation information.
+        publish_id: The ID of the publishing entry.
+        default_lang: The default language code.
+        approved: Approval status.
+        changed: The last modified date.
+        desk_flow: Desk flow status.
+        dir_flow: Directory flow status.
     """
 
-    navn: Navn
-    kortnavn: str
-    gamle_emnekoder: str
-    forstegangspublisering: str
+    name: Name | str
+    short_name: str
+    old_subjectcodes: str | None
+    firstpubilishing: str
     status: str
-    eierseksjon: Eierseksjon
-    kontakter: list[Kontakt]
-    triggerord: dict[str, list[dict[str, str]]]
-    varianter: list[Variant]
-    regionale_nivaer: list[str]
-    videreforing: dict[str, bool]
-    statid: str
+    owningsection: Owningsection
+    contacts: list[Contact] | None
+    triggerwords: dict[str, list[dict[str, str]]] | None
+    variants: list[Variant] | list[str]
+    regional_levels: list[str]
+    continuation: dict[str, bool] | None
+    publish_id: str
     default_lang: str
-    godkjent: str
-    endret: str
-    desk_flyt: str
-    dir_flyt: str
+    approved: str | None
+    changed: str | list[str]
+    desk_flow: str | None
+    dir_flow: str | None
+
+    annual_reporting: bool | None
+    start_year: str | None
+    changes: list[str] | None
 
 
 def parse_lang_text_single(entry: dict[str, Any]) -> LangText:
@@ -198,53 +202,54 @@ def parse_lang_text_single(entry: dict[str, Any]) -> LangText:
     return LangText(
         lang=entry["@{http://www.w3.org/XML/1998/namespace}lang"],
         text=entry.get(TEXT, None),
-        navn=entry.get("@navn", None),
+        name=entry.get("@navn", None),
     )
 
 
-def parse_navn_single(entry: dict[str, Any]) -> Navn:
-    """Parses a dictionary entry into a Navn object.
+def parse_name_single(entry: dict[str, Any]) -> Name:
+    """Parses a dictionary entry into a Name object.
 
     Args:
         entry: The dictionary entry to parse.
 
     Returns:
-        Navn: The parsed Navn object.
+        Name: The parsed Name object.
     """
-    return Navn(navn_lang=[parse_lang_text_single(e) for e in entry["navn"]])
+    return Name(name_lang=[parse_lang_text_single(e) for e in entry["navn"]])
 
 
-def parse_kontakt_single(entry: dict[str, Any]) -> Kontakt:
-    """Parses a dictionary entry into a Kontakt object.
+def parse_contact_single(entry: dict[str, Any]) -> Contact:
+    """Parses a dictionary entry into a Contact object.
 
     Args:
         entry: The dictionary entry to parse.
 
     Returns:
-        Kontakt: The parsed Kontakt object.
+        Contact: The parsed Kontakt object.
     """
-    navn = [parse_lang_text_single(e) for e in entry["navn"]]
-    return Kontakt(
-        navn=navn,
-        statid=entry["@id"],
-        telefon=entry["@telefon"],
-        mobil=entry["@mobil"],
-        epost=entry["@epost"],
-        initialer=entry["@initialer"],
+    name = Name(name_lang=[parse_lang_text_single(e) for e in entry["navn"]])
+    return Contact(
+        name=name,
+        contact_id=entry["@id"],
+        phone=entry["@telefon"],
+        cellphone=entry["@mobil"],
+        email=entry["@epost"],
+        initials=entry["@initialer"],
+        changed=entry.get("@endret", None),
     )
 
 
-def parse_eierseksjon_single(entry: dict[str, Any]) -> Eierseksjon:
-    """Parses a dictionary entry into an Eierseksjon object.
+def parse_eierseksjon_single(entry: dict[str, Any]) -> Owningsection:
+    """Parses a dictionary entry into an Owningsection object.
 
     Args:
         entry: The dictionary entry to parse.
 
     Returns:
-        Eierseksjon: The parsed Eierseksjon object.
+        Owningsection: The parsed Owningsection object.
     """
-    navn = [parse_lang_text_single(e) for e in entry["navn"]]
-    return Eierseksjon(navn=navn, statid=entry["@id"])
+    name = [parse_lang_text_single(e) for e in entry["navn"]]
+    return Owningsection(name=name, section_id=entry["@id"])
 
 
 def parse_triggerord_single(entry: dict[str, Any]) -> dict[str, str]:
@@ -272,13 +277,13 @@ def parse_variant_single(entry: dict[str, Any]) -> Variant:
         Variant: The parsed Variant object.
     """
     return Variant(
-        navn=entry["navn"],
-        statid=entry["@id"],
-        revisjon=entry["@revisjon"],
-        opphort=entry["@opphort"],
-        detaljniva=entry["@detaljniva"],
-        detaljniva_en=entry["@detaljniva_EN"],
-        frekvens=entry["@frekvens"],
+        name=entry["navn"],
+        variant_id=entry["@id"],
+        revision=entry["@revisjon"],
+        ceased=entry["@opphort"],
+        detail_level=entry["@detaljniva"],
+        detail_level_en=entry["@detaljniva_EN"],
+        frequency=entry["@frekvens"],
     )
 
 
@@ -291,60 +296,64 @@ def parse_data_single(root: dict[str, Any]) -> SinglePublishing:
     Returns:
         SinglePublishing: The parsed SinglePublishing object.
     """
-    navn = parse_navn_single(root["navn"])
-    kortnavn = root["kortnavn"][TEXT]
-    gamle_emnekoder = root["gamleEmnekoder"]
-    forstegangspublisering = root["forstegangspublisering"]
+    name = parse_name_single(root["navn"])
+    short_name = root["kortnavn"][TEXT]
+    old_subjectcodes = root["gamleEmnekoder"]
+    firstpublishing = root["forstegangspublisering"]
     try:
-        forstegangspublisering = dateutil.parser.parse(forstegangspublisering).date()
+        firstpublishing = dateutil.parser.parse(firstpublishing).date()
     except ValueError:
         pass
     status = root["status"]["@kode"]
-    eierseksjon = parse_eierseksjon_single(root["eierseksjon"])
-    kontakter = [parse_kontakt_single(e) for e in root["kontakter"]["kontakt"]]
-    triggerord = {
+    owningsection = parse_eierseksjon_single(root["eierseksjon"])
+    contacts = [parse_contact_single(e) for e in root["kontakter"]["kontakt"]]
+    triggerwords = {
         k: [parse_triggerord_single(e) for e in v]
         for k, v in root["triggerord"].items()
     }
     # Some times single variants are not in a list already?
     if not isinstance(root["varianter"]["variant"], list):
         root["varianter"]["variant"] = [root["varianter"]["variant"]]
-    varianter = [
+    variants = [
         parse_variant_single(variant) for variant in root["varianter"]["variant"]
     ]
-    regionale_nivaer = root["regionaleNivaer"]["kode"]
-    videreforing = {
+    regional_levels = root["regionaleNivaer"]["kode"]
+    continuation = {
         k.replace("@", ""): v == "true" for k, v in root["videreforing"].items()
     }
-    statid = root["@id"]
+    publish_id = root["@id"]
     default_lang = root["@defaultLang"]
-    godkjent = root["@godkjent"]
-    endret = root[ENDRET]
+    approved = root["@godkjent"]
+    changed = root[ENDRET]
     try:
-        endret = dateutil.parser.parse(endret)
+        changed = dateutil.parser.parse(changed)
     except ValueError:
         pass
-    desk_flyt = root[DESKFLYT]
-    dir_flyt = root["@dirFlyt"]
+    desk_flow = root[DESKFLYT]
+    dir_flow = root["@dirFlyt"]
 
     return SinglePublishing(
-        navn=navn,
-        kortnavn=kortnavn,
-        gamle_emnekoder=gamle_emnekoder,
-        forstegangspublisering=forstegangspublisering,
+        name=name,
+        short_name=short_name,
+        old_subjectcodes=old_subjectcodes,
+        firstpubilishing=firstpublishing,
         status=status,
-        eierseksjon=eierseksjon,
-        kontakter=kontakter,
-        triggerord=triggerord,
-        varianter=varianter,
-        regionale_nivaer=regionale_nivaer,
-        videreforing=videreforing,
-        statid=statid,
+        owningsection=owningsection,
+        contacts=contacts,
+        triggerwords=triggerwords,
+        variants=variants,
+        regional_levels=regional_levels,
+        continuation=continuation,
+        publish_id=publish_id,
         default_lang=default_lang,
-        godkjent=godkjent,
-        endret=endret,
-        desk_flyt=desk_flyt,
-        dir_flyt=dir_flyt,
+        approved=approved,
+        changed=changed,
+        desk_flow=desk_flow,
+        dir_flow=dir_flow,
+        # Missing from this endpoint
+        annual_reporting=None,
+        start_year=None,
+        changes=None,
     )
 
 
@@ -358,22 +367,22 @@ def kwargs_specifics(nested: dict[str, Any]) -> dict[str, Any]:
         dict[str, Any]: Cleaned up data-structure
     """
     return {
-        "navn": nested["publisering"]["navn"],
-        "statid": nested["publisering"]["@id"],
-        "statistikk": nested["publisering"]["@statistikk"],
+        "name": nested["publisering"]["navn"],
+        "stat_id": nested["publisering"]["@id"],
+        "statistic": nested["publisering"]["@statistikk"],
         "variant": nested["publisering"]["@variant"],
         "status": nested["publisering"]["@status"],
-        "er_periode": nested["publisering"]["@erPeriode"] == "true",
-        "periode_fra": dateutil.parser.parse(nested["publisering"]["@periodeFra"]),
-        "periode_til": dateutil.parser.parse(nested["publisering"]["@periodeTil"]),
-        "presisjon": nested["publisering"]["@presisjon"],
-        "tidspunkt": dateutil.parser.parse(nested["publisering"]["@tidspunkt"]),
-        "er_endret": nested["publisering"]["@erEndret"] == "true",
-        "desk_flyt": nested["publisering"][DESKFLYT],
-        "endret": dateutil.parser.parse(nested["publisering"][ENDRET]),
-        "er_avlyst": nested["publisering"]["@erAvlyst"] == "true",
-        "revisjon": nested["publisering"]["@revisjon"],
-        "tittel": nested["publisering"]["@tittel"],
+        "is_period": nested["publisering"]["@erPeriode"] == "true",
+        "period_from": dateutil.parser.parse(nested["publisering"]["@periodeFra"]),
+        "period_until": dateutil.parser.parse(nested["publisering"]["@periodeTil"]),
+        "precision": nested["publisering"]["@presisjon"],
+        "time": dateutil.parser.parse(nested["publisering"]["@tidspunkt"]),
+        "has_changed": nested["publisering"]["@erEndret"] == "true",
+        "desk_flow": nested["publisering"][DESKFLYT],
+        "time_changed": dateutil.parser.parse(nested["publisering"][ENDRET]),
+        "is_cancelled": nested["publisering"]["@erAvlyst"] == "true",
+        "revision": nested["publisering"]["@revisjon"],
+        "title": nested["publisering"]["@tittel"],
     }
 
 
@@ -381,13 +390,64 @@ def kwargs_specifics(nested: dict[str, Any]) -> dict[str, Any]:
 def get_statistics_register() -> list[dict[str, Any]]:
     """Get the overview of all the statistical products from the API.
 
+    Warning: this may take a little time to fetch.
+
     Returns:
         dict[str, Any]: The summary of all the products.
     """
-    response = rs.get("https://i.ssb.no/statistikkregisteret/statistics")
+    response = rs.get(
+        "https://i.ssb.no/statistikkregisteret/statistikk/listAllReleasedAsJson"
+    )
     response.raise_for_status()
     stats: list[dict[str, Any]] = response.json()["statistics"]
     return stats
+
+
+@lru_cache(maxsize=1)
+def get_contacts() -> list[Contact]:
+    """Get all the contacts from the API.
+
+    Returns:
+        list[Contacts]: Each of the contacts in a list.
+    """
+    response = rs.get("https://i.ssb.no/statistikkregisteret/kontakt/listSomXml")
+    response.raise_for_status()
+    return parse_contacts(ET.fromstring(response.text))
+
+
+def parse_contacts(t: ET.Element) -> list[Contact]:
+    """Parse the content of contacts into Contact dataclasses.
+
+    Args:
+        t: The xml-element to look for contacts in.
+
+    Returns:
+        list[Contact]: The parsed data inserted into the dataclasses.
+    """
+    content = etree_to_dict(t)
+    result: list[Contact] = []
+    for contact in content["kontakter"]["kontakt"]:
+        result.append(
+            Contact(
+                name=Name(
+                    name_lang=[
+                        LangText(
+                            lang=x["@{http://www.w3.org/XML/1998/namespace}lang"],
+                            text=x.get("#text", None),
+                            name=x.get("@navn", None),
+                        )
+                        for x in contact["navn"]
+                    ]
+                ),
+                contact_id=contact["@id"],
+                phone=contact["@telefon"],
+                cellphone=contact["@mobil"],
+                email=contact["@epost"],
+                initials=contact["@initialer"],
+                changed=dateutil.parser.parse(contact["@endret"]),
+            )
+        )
+    return result
 
 
 def find_stat_shortcode(
@@ -504,21 +564,21 @@ def find_publishings(
             publish["specifics"] = specific_publishing(publish["@id"])
 
     return MultiplePublishings(
-        publiseringer=[
+        publishings=[
             StatisticPublishingShort(
-                statid=pub["@id"],
+                publish_id=pub["@id"],
                 variant=pub["@variant"],
-                desk_flyt=pub[DESKFLYT],
-                endret=dateutil.parser.parse(pub[ENDRET]),
-                statistikk_kortnavn=pub["@statistikkKortnavn"],
+                desk_flow=pub[DESKFLYT],
+                time_changed=dateutil.parser.parse(pub[ENDRET]),
+                short_name=pub["@statistikkKortnavn"],
                 specifics=pub[
                     "specifics"
                 ],  # Already in the correct class from specific_p
             )
             for pub in publishings["publisering"]
         ],
-        antall=int(publishings["@antall"]),
-        dato=publishings["@dato"],
+        amount=int(publishings["@antall"]),
+        date=publishings["@dato"],
     )
 
 
@@ -593,48 +653,6 @@ def specific_publishing(publish_id: str = "162143") -> PublishingSpecifics:
     return PublishingSpecifics(**kwargs_specifics(nested))
 
 
-def etree_to_dict(t: ET.Element) -> dict[str, Any]:
-    """Convert an XML-tree to a python dictionary.
-
-    Args:
-        t: The XML element to convert.
-
-    Returns:
-        dict[str, Any]: The python dictionary that has been converted to.
-    """
-    d: dict[str, Any] = {t.tag: {} if t.attrib else None}
-    children = list(t)
-    if children:
-        d = handle_children(children, t)
-    if t.attrib:
-        d[t.tag].update(("@" + k, v) for k, v in t.attrib.items())
-    if t.text:
-        text = t.text.strip()
-        if children or t.attrib:
-            if text:
-                d[t.tag][TEXT] = text
-        else:
-            d[t.tag] = text
-    return d
-
-
-def handle_children(children: list[ET.Element], t: ET.Element) -> dict[str, Any]:
-    """Handle children in the etree.
-
-    Args:
-        children: The children to treat.
-        t: The XML element to convert.
-
-    Returns:
-        dict[str, Any]: The python dictionary of the children part.
-    """
-    dd = defaultdict(list)
-    for dc in map(etree_to_dict, children):
-        for k, v in dc.items():
-            dd[k].append(v)
-    return {t.tag: {k: v[0] if len(v) == 1 else v for k, v in dd.items()}}
-
-
 def raise_on_missing_future_publish(
     shortname: str, raise_error: bool = True
 ) -> datetime.timedelta | None:
@@ -684,3 +702,122 @@ def _raise_publisherror_possibly(raise_error: bool, msg: str) -> None:
         raise FuturePublishingError(msg)
     logger.warning(msg)
     return None
+
+
+def sections_publishings(
+    section_code: str | int,
+    include_ceased: bool = False,
+    get_publishings: bool = True,
+    get_publishing_specifics: bool = True,
+) -> list[SinglePublishing]:
+    """Get the publishings for a specific owning section at statistics norway.
+
+    Args:
+        section_code: The three digit numeric code for the section.
+        include_ceased: Set to True if you want to include statistical products that have ceased publiscation. Defaults to False.
+        get_publishings: Get more data about all the publishings. Defaults to True.
+        get_publishing_specifics: Get more data about every single publishing. Defaults to True.
+
+    Returns:
+        list[SinglePublishing]: A list of the sections statistical products.
+    """
+    register = get_statistics_register()
+    section_code_str = str(section_code)
+    content = [
+        parse_single_stat_from_englishjson(stat)
+        for stat in register
+        if stat["ownerCode"] == section_code_str
+    ]
+    if not include_ceased:
+        content = [
+            stat for stat in content if "opphørt" not in stat.name.name_lang[0].name
+        ]
+    if get_publishings:
+        for i, stat in enumerate(content):
+            content[i].publishings = find_publishings(
+                stat.short_name, get_publishing_specifics
+            )
+    return content
+
+
+def parse_single_stat_from_englishjson(stat: dict[str, Any]) -> SinglePublishing:
+    """Insert data-parts from the english json endpoint into SinglePublishing object.
+
+    Args:
+        stat: The datapart that represents the statistic.
+
+    Returns:
+        SinglePublishing: A SinglePublishing object with inserted data.
+    """
+    return SinglePublishing(
+        publish_id=stat["id"],
+        short_name=stat["shortName"],
+        name=Name(
+            name_lang=[
+                LangText(name=stat["name"], lang="no"),
+                LangText(name=stat["nameEN"], lang="en"),
+            ]
+        ),
+        created_date=dateutil.parser.parse(stat["dateCreated"]),
+        default_lang=stat["lang"],
+        owningsection=Owningsection(
+            name=[LangText(name=stat["owner"], lang="no")], section_id=stat["ownerCode"]
+        ),
+        status=stat["status"],
+        regional_levels=stat["regionalLevels"].split(";"),
+        variants=stat["variants"].split(";"),
+        annual_reporting=stat["annualReporting"],
+        start_year=stat["startYear"],
+        firstpubilishing=stat["firstReleaseStatistic"],
+        changes=stat["changes"],
+        # Not available from the english json endpoint
+        contacts=None,
+        triggerwords=None,
+        continuation=None,
+        approved=None,
+        desk_flow=None,
+        dir_flow=None,
+        old_subjectcodes=None,
+    )
+
+
+def etree_to_dict(t: ET.Element) -> dict[str, Any]:
+    """Convert an XML-tree to a python dictionary.
+
+    Args:
+        t: The XML element to convert.
+
+    Returns:
+        dict[str, Any]: The python dictionary that has been converted to.
+    """
+    d: dict[str, Any] = {t.tag: {} if t.attrib else None}
+    children = list(t)
+    if children:
+        d = handle_children(children, t)
+    if t.attrib:
+        d[t.tag].update(("@" + k, v) for k, v in t.attrib.items())
+    if t.text:
+        text = t.text.strip()
+        if children or t.attrib:
+            if text:
+                d[t.tag][TEXT] = text
+        else:
+            d[t.tag] = text
+    return d
+
+
+def handle_children(children: list[ET.Element], t: ET.Element) -> dict[str, Any]:
+    """Handle children in the etree.
+
+    Args:
+        children: The children to treat.
+        t: The XML element to convert.
+
+    Returns:
+        dict[str, Any]: The python dictionary of the children part.
+    """
+    dd = defaultdict(list)
+    for dc in map(etree_to_dict, children):
+        for k, v in dc.items():
+            dd[k].append(v)
+    return {t.tag: {k: v[0] if len(v) == 1 else v for k, v in dd.items()}}

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -161,7 +161,7 @@ class SinglePublishing:
         name: The name details.
         short_name: The short name.
         old_subjectcodes: The old subject codes.
-        firstpubilishing: The first publication date.
+        firstpublishing: The first publication date.
         status: The status code.
         owner_name: The ownership section name.
         owner_code: The ownership section code.
@@ -181,7 +181,7 @@ class SinglePublishing:
     name: Name | str
     short_name: str
     old_subjectcodes: str | None
-    firstpubilishing: str
+    firstpublishing: str
     status: str
     owningsection: Owningsection
     contacts: list[Contact] | None
@@ -350,7 +350,7 @@ def parse_data_single(root: dict[str, Any]) -> SinglePublishing:
         name=name,
         short_name=short_name,
         old_subjectcodes=old_subjectcodes,
-        firstpubilishing=firstpublishing,
+        firstpublishing=firstpublishing,
         status=status,
         owningsection=owningsection,
         contacts=contacts,
@@ -789,7 +789,7 @@ def parse_single_stat_from_englishjson(stat: dict[str, Any]) -> SinglePublishing
         variants=stat["variants"].split(";"),
         annual_reporting=stat["annualReporting"],
         start_year=stat["startYear"],
-        firstpubilishing=stat["firstReleaseStatistic"],
+        firstpublishing=stat["firstReleaseStatistic"],
         changes=stat["changes"],
         # Not available from the english json endpoint
         contacts=None,

--- a/src/fagfunksjoner/api/statistikkregisteret.py
+++ b/src/fagfunksjoner/api/statistikkregisteret.py
@@ -14,6 +14,7 @@ from fagfunksjoner.fagfunksjoner_logger import logger
 TEXT = "#text"
 ENDRET = "@endret"
 DESKFLYT = "@deskFlyt"
+SPACE_LANG = r"@{http://www.w3.org/XML/1998/namespace}lang"
 
 
 STATUS_MAP = {
@@ -214,7 +215,7 @@ def parse_lang_text_single(entry: dict[str, Any]) -> LangText:
         LangText: The parsed LangText object.
     """
     return LangText(
-        lang=entry["@{http://www.w3.org/XML/1998/namespace}lang"],
+        lang=entry[SPACE_LANG],
         text=entry.get(TEXT, None),
         name=entry.get("@navn", None),
     )
@@ -249,7 +250,7 @@ def parse_contact_single(entry: dict[str, Any]) -> Contact:
         cellphone=entry["@mobil"],
         email=entry["@epost"],
         initials=entry["@initialer"],
-        changed=entry.get("@endret", None),
+        changed=entry.get(ENDRET, None),
     )
 
 
@@ -276,7 +277,7 @@ def parse_triggerord_single(entry: dict[str, Any]) -> dict[str, str]:
         dict: The parsed trigger word dictionary.
     """
     return {
-        "lang": entry["@{http://www.w3.org/XML/1998/namespace}lang"],
+        "lang": entry[SPACE_LANG],
         "text": entry[TEXT],
     }
 
@@ -450,7 +451,7 @@ def parse_contacts(t: ET.Element) -> list[Contact]:
                 name=Name(
                     name_lang=[
                         LangText(
-                            lang=x["@{http://www.w3.org/XML/1998/namespace}lang"],
+                            lang=x[SPACE_LANG],
                             text=x.get("#text", None),
                             name=x.get("@navn", None),
                         )
@@ -462,7 +463,7 @@ def parse_contacts(t: ET.Element) -> list[Contact]:
                 cellphone=contact["@mobil"],
                 email=contact["@epost"],
                 initials=contact["@initialer"],
-                changed=dateutil.parser.parse(contact["@endret"]),
+                changed=dateutil.parser.parse(contact[ENDRET]),
             )
         )
     return result

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -836,7 +836,7 @@ def add_dollar_or_nondollar_path(
             )
         )
         paths += [new_path]
-        logger.info(
+        logger.debug(
             f"Path after adding dollar '{new_path}', replacing non-dollar: '{non_dollar_path.as_posix()!s}' with '${dollar}', paths: {paths}"
         )
     return paths
@@ -877,7 +877,7 @@ def go_back_in_time(
                     + curr_path.name[year_range[1] :]
                 )
                 curr_path = Path(curr_path.parent, name_update)
-                logger.info(f"Looking back at {looking_back}, {curr_path=}")
+                logger.debug(f"Looking back at {looking_back}, {curr_path=}")
             yr_combinations = get_path_combinations(curr_path, file_exts=exts)
             for yrpath, ext in yr_combinations:
                 url_address = url_from_path(yrpath.with_suffix(ext))

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -607,7 +607,7 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
             filelist = [x for x in filelist if x.stem == path_lib.stem]
             logger.info(f"{filelist=}")
             # If more than one, we cannot now which one you want...
-            if len(filelist) > 2:
+            if len(filelist) >= 2:
                 msg = f"Found more than one matching file {filelist}. Specify file ending please."
                 raise FileNotFoundError(msg)
             elif len(filelist) == 0:

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -589,6 +589,7 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
     file_combinations = get_path_combinations(
         path_lib, file_exts=None, add_dollar=False
     )
+    logger.info(f"Will try combinations: {file_combinations}")
     # Correcting path in
     if path_lib.is_file():
         filepath = path_lib
@@ -606,7 +607,7 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
                 raise FileNotFoundError(msg)
             elif len(filelist) == 0:
                 msg = (
-                    "Found no file matching the name {filepath} in the folder: {folder}"
+                    f"Found no file matching the name {filepath} in the folder: {path_lib.parent}"
                 )
                 raise FileNotFoundError(msg)
             # Replace filepath with file we found matching name

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -603,6 +603,8 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
         else:
             # Last resort, see if any file matches stripping the extensions
             filelist = list(path_lib.parent.glob(path_lib.stem + "*"))
+            # Shorten filelist to only those matching stem
+            filelist = [x for x in filelist if x.stem == path_lib.stem]
             # If more than one, we cannot now which one you want...
             if len(filelist) > 2:
                 msg = f"Found more than one matching file {filelist}. Specify file ending please."

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -876,6 +876,7 @@ def go_back_in_time(
                     + path_lib.name[year_range[1] :]
                 )
                 new_path = Path(path_lib.parent, name_update)
+                logger.info(f"Looking back at {looking_back}, {new_path=}")
             yr_combinations = get_path_combinations(new_path, file_exts=exts)
             for yrpath, ext in yr_combinations:
                 url_address = url_from_path(yrpath.with_suffix(ext))

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -587,8 +587,8 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
     logger.info(f"Found datadok-response for path {url_path}")
 
     file_combinations = get_path_combinations(
-        path_lib, file_exts=None, add_dollar=False
-    )
+        path_lib.with_suffix(""), file_exts=None, add_dollar=False
+    )  # file_exts=None gets replaced by dat, txt, ""
     logger.info(f"Will try combinations: {file_combinations}")
     # Correcting path in
     if path_lib.is_file():
@@ -784,11 +784,12 @@ def add_dollar_or_nondollar_path(
     stammer = linux_shortcuts()
     if str(path_lib).startswith("$"):
         dollar: str = (
-            str(path_lib.parents[-1]).replace("$", "").replace("_PII", "").upper()
+            str(path_lib.parts[0]).replace("$", "").replace("_PII", "").upper()
         )
         non_dollar = stammer.get(dollar, None)
         if non_dollar is not None:
-            new_path = Path(non_dollar, *path_lib.parts[2:])
+            new_path = Path(non_dollar, *path_lib.parts[1:])
+            logger.info(f"Constructed new_path {new_path} from dollar {dollar} and non_dollar {non_dollar} from path {path_lib}")
             paths += [new_path]
     elif add_dollar:
         if len(path_lib.parts) >= 4:

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -872,7 +872,7 @@ def go_back_in_time(
                 yr = path_lib.name[year_range[0] : year_range[1]]
                 name_update = (
                     path_lib.name[: year_range[0]]
-                    + str(int(yr) - 1)
+                    + str(int(yr) + looking_back)
                     + path_lib.name[year_range[1] :]
                 )
                 new_path = Path(path_lib.parent, name_update)

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -866,18 +866,19 @@ def go_back_in_time(
     yr_char_ranges = get_yr_char_ranges(path_lib)
     # Loop over the years we want to look at, changing all the year ranges in the path
     if yr_char_ranges:
+        curr_path = path_lib
         # Looking 20 years back in time
         for looking_back in range(-1, -20, -1):
             for year_range in yr_char_ranges:
-                yr = path_lib.name[year_range[0] : year_range[1]]
+                yr = curr_path.name[year_range[0] : year_range[1]]
                 name_update = (
-                    path_lib.name[: year_range[0]]
-                    + str(int(yr) + looking_back)
-                    + path_lib.name[year_range[1] :]
+                    curr_path.name[: year_range[0]]
+                    + str(int(yr) - 1)
+                    + curr_path.name[year_range[1] :]
                 )
-                new_path = Path(path_lib.parent, name_update)
-                logger.info(f"Looking back at {looking_back}, {new_path=}")
-            yr_combinations = get_path_combinations(new_path, file_exts=exts)
+                curr_path = Path(curr_path.parent, name_update)
+                logger.info(f"Looking back at {looking_back}, {curr_path=}")
+            yr_combinations = get_path_combinations(curr_path, file_exts=exts)
             for yrpath, ext in yr_combinations:
                 url_address = url_from_path(yrpath.with_suffix(ext))
                 if test_url(url_address):

--- a/src/fagfunksjoner/data/datadok_extract.py
+++ b/src/fagfunksjoner/data/datadok_extract.py
@@ -605,6 +605,7 @@ def open_path_datadok(path: str | Path, **read_fwf_params: Any) -> ArchiveData:
             filelist = list(path_lib.parent.glob(path_lib.stem + "*"))
             # Shorten filelist to only those matching stem
             filelist = [x for x in filelist if x.stem == path_lib.stem]
+            logger.info(f"{filelist=}")
             # If more than one, we cannot now which one you want...
             if len(filelist) > 2:
                 msg = f"Found more than one matching file {filelist}. Specify file ending please."

--- a/tests/api/test_statistikkregisteret.py
+++ b/tests/api/test_statistikkregisteret.py
@@ -19,7 +19,7 @@ from fagfunksjoner.api.statistikkregisteret import (
 
 @responses.activate
 def test_get_statistics_register():
-    url = "https://i.ssb.no/statistikkregisteret/statistics"
+    url = "https://i.ssb.no/statistikkregisteret/statistikk/listAllReleasedAsJson"
     mock_response = {"statistics": [{"id": "1", "shortName": "test"}]}
 
     responses.add(responses.GET, url, json=mock_response, status=200)
@@ -33,7 +33,9 @@ def test_get_statistics_register():
 
 @responses.activate
 def test_find_stat_shortcode():
-    url_statistics = "https://i.ssb.no/statistikkregisteret/statistics"
+    url_statistics = (
+        "https://i.ssb.no/statistikkregisteret/statistikk/listAllReleasedAsJson"
+    )
     url_single_stat = "https://i.ssb.no/statistikkregisteret/statistikk/xml/1"
     url_publishings = "https://i.ssb.no/statistikkregisteret/publisering/listKortnavnSomXml?kortnavn=test"
     url_specific_publishing = "https://i.ssb.no/statistikkregisteret/publisering/xml/1"
@@ -111,14 +113,14 @@ def test_find_stat_shortcode():
     assert isinstance(result, list)
     assert result[0]["id"] == "1"
     assert result[0]["shortName"] == "test"
-    assert hasattr(result[0]["publishings"].publiseringer[0], "specifics")
-    assert result[0]["publishings"].publiseringer[0].specifics.statid == "162143"
+    assert hasattr(result[0]["publishings"].publishings[0], "specifics")
+    assert result[0]["publishings"].publishings[0].specifics.statid == "162143"
 
     assert isinstance(time_until_publishing("test"), datetime.timedelta)
-    assert single_stat("1").triggerord["triggerord"][0]["lang"] == "no"
-    assert isinstance(find_latest_publishing("test").endret, datetime.datetime)
-    assert find_publishings("test").publiseringer[0].statid.isdigit()
-    assert isinstance(specific_publishing("1").er_avlyst, bool)
+    assert single_stat("1").triggerwords["triggerord"][0]["lang"] == "no"
+    assert isinstance(find_latest_publishing("test").time_changed, datetime.datetime)
+    assert find_publishings("test").publishings[0].statid.isdigit()
+    assert isinstance(specific_publishing("1").is_cancelled, bool)
 
 
 @pytest.fixture

--- a/tests/api/test_statistikkregisteret.py
+++ b/tests/api/test_statistikkregisteret.py
@@ -114,12 +114,12 @@ def test_find_stat_shortcode():
     assert result[0]["id"] == "1"
     assert result[0]["shortName"] == "test"
     assert hasattr(result[0]["publishings"].publishings[0], "specifics")
-    assert result[0]["publishings"].publishings[0].specifics.statid == "162143"
+    assert result[0]["publishings"].publishings[0].specifics.publish_id == "162143"
 
     assert isinstance(time_until_publishing("test"), datetime.timedelta)
     assert single_stat("1").triggerwords["triggerord"][0]["lang"] == "no"
     assert isinstance(find_latest_publishing("test").time_changed, datetime.datetime)
-    assert find_publishings("test").publishings[0].statid.isdigit()
+    assert find_publishings("test").publishings[0].stat_id.isdigit()
     assert isinstance(specific_publishing("1").is_cancelled, bool)
 
 

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -478,7 +478,14 @@ def test_file_with_ark_extension(
     utd_path, path, expected = utd_path_expected()
     mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
-    mock_import_archive_data.return_value = pd.DataFrame()
+    mock_import_archive_data.return_value = datadok_extract.ArchiveData(
+                                                        df=pd.DataFrame(),
+                                                        metadata_df=pd.DataFrame(),
+                                                        codelist_df=pd.DataFrame(),
+                                                        codelist_dict={"":{"":""}},
+                                                        names=[""]
+                                                        widths=[1]
+                                                        datatypes={"":""})
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -486,7 +493,7 @@ def test_file_with_ark_extension(
         ark_file.open("a").close()
         result = datadok_extract.open_path_datadok(ark_file)
         mock_import_archive_data.assert_called_once_with(ANY, ark_file)
-        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result, datadok_extract.ArchiveData)
 
 
 @patch("fagfunksjoner.data.datadok_extract.linux_shortcuts")

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -1,10 +1,9 @@
 import math
-import os
 import tempfile
-from pathlib import Path
 import xml.etree.ElementTree as ET
 from datetime import datetime
-from unittest.mock import mock_open, patch, ANY
+from pathlib import Path
+from unittest.mock import ANY, mock_open, patch
 
 import pandas as pd
 import pytest
@@ -275,22 +274,8 @@ def test_handle_decimals_with_empty_metadata():
 @patch("pandas.read_fwf")
 def test_import_archive_data_with_url(mock_read_fwf, mock_open, mock_requests_get):
     # Mocking the XML response from the URL
-    mock_requests_get.return_value.text = """
-    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
-        <meta:ContactInformation>
-            <common:Division>Test Division</common:Division>
-        </meta:ContactInformation>
-        <meta:ContextVariable id="1">
-            <meta:Title>Variable Title</meta:Title>
-            <meta:Description>Variable Description</meta:Description>
-            <meta:Properties>
-                <meta:Datatype>Tekst</meta:Datatype>
-                <meta:Length>10</meta:Length>
-                <meta:StartPosition>1</meta:StartPosition>
-            </meta:Properties>
-        </meta:ContextVariable>
-    </root>
-    """
+    mock_requests_get.return_value.text = xml_content()
+    mock_requests_get.return_value.status_code = 200
 
     # Mocking the DataFrame returned by pd.read_fwf
     mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -301,8 +286,8 @@ def test_import_archive_data_with_url(mock_read_fwf, mock_open, mock_requests_ge
         archive_desc_xml="http://example.com/mock.xml", archive_file="mock_archive.txt"
     )
 
-    # Check if requests.get was called
-    mock_requests_get.assert_called_once_with("http://example.com/mock.xml")
+    # Check if requests.get was called (called by both url_test and actual get)
+    mock_requests_get.assert_called_with("http://example.com/mock.xml")
 
     # Check if pd.read_fwf was called with the correct parameters
     mock_read_fwf.assert_called_once()
@@ -314,28 +299,35 @@ def test_import_archive_data_with_url(mock_read_fwf, mock_open, mock_requests_ge
     assert archive_data.metadata_df["title"].iloc[0] == "Variable Title"
 
 
+def xml_content():
+    return """<root xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ssb.no/ns/meta">
+    <Title>Example Dataset</Title>
+    <Description>Sample description of the dataset</Description>
+    <Type>SampleType</Type>
+    <ContactInformation>
+        <Person xmlns="http://www.ssb.no/ns/meta/common">John Doe</Person>
+        <Division xmlns="http://www.ssb.no/ns/meta/common">Sample Division</Division>
+    </ContactInformation>
+    <ContextVariable id="urn:example:contextvariable:dataset:1234567" datasetId="urn:example:dataset:1234567">
+        <Title>Variable Title</Title>
+        <Description>Sample Variable 1</Description>
+        <Properties>
+            <Datatype>String</Datatype>
+            <Length>10</Length>
+            <StartPosition>1</StartPosition>
+        </Properties>
+    </ContextVariable>
+    </root>"""
+
+
 @patch("requests.get")
-@patch("builtins.open", new_callable=mock_open, read_data="<root></root>")
+@patch("builtins.open", new_callable=mock_open, read_data=xml_content())
 @patch("pandas.read_fwf")
 def test_import_archive_data_with_file(mock_read_fwf, mock_open, mock_requests_get):
     # Simulate the file-based XML content with ContactInformation element
-    xml_content = """
-    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
-        <meta:ContactInformation>
-            <common:Division>Test Division</common:Division>
-        </meta:ContactInformation>
-        <meta:ContextVariable id="1">
-            <meta:Title>Variable Title</meta:Title>
-            <meta:Description>Variable Description</meta:Description>
-            <meta:Properties>
-                <meta:Datatype>Tekst</meta:Datatype>
-                <meta:Length>10</meta:Length>
-                <meta:StartPosition>1</meta:StartPosition>
-            </meta:Properties>
-        </meta:ContextVariable>
-    </root>
-    """
-    mock_open.return_value.read.return_value = xml_content
+
+    mock_open.return_value.read.return_value = xml_content()
+    mock_requests_get.return_value.status_code = 500  # Cause to look for file instead
 
     # Mocking the DataFrame returned by pd.read_fwf
     mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
@@ -366,23 +358,7 @@ def test_import_archive_data_with_invalid_params(
     mock_read_fwf, mock_open, mock_requests_get
 ):
     # Simulate the file-based XML content with ContactInformation element
-    xml_content = """
-    <root xmlns:meta="http://www.ssb.no/ns/meta" xmlns:common="http://www.ssb.no/ns/meta/common">
-        <meta:ContactInformation>
-            <common:Division>Test Division</common:Division>
-        </meta:ContactInformation>
-        <meta:ContextVariable id="1">
-            <meta:Title>Variable Title</meta:Title>
-            <meta:Description>Variable Description</meta:Description>
-            <meta:Properties>
-                <meta:Datatype>Tekst</meta:Datatype>
-                <meta:Length>10</meta:Length>
-                <meta:StartPosition>1</meta:StartPosition>
-            </meta:Properties>
-        </meta:ContextVariable>
-    </root>
-    """
-    mock_open.return_value.read.return_value = xml_content
+    mock_open.return_value.read.return_value = xml_content()
 
     # Now, we expect a ValueError related to the dtype parameter
     with pytest.raises(ValueError, match="You cannot pass dtype to pandas.fwf"):
@@ -402,7 +378,7 @@ def test_import_archive_data_parse_error():
     with patch("builtins.open", mock_open(read_data=invalid_xml_content)):
         with pytest.raises(ET.ParseError):
             datadok_extract.import_archive_data(
-                archive_desc_xml="https://mock.xml", archive_file="mock_archive.txt"
+                archive_desc_xml="mock.xml", archive_file="mock_archive.txt"
             )
 
 
@@ -411,10 +387,12 @@ def test_import_archive_data_parse_error():
 def test_get_path_combinations_basic(mock_get_key_by_value, mock_linux_shortcuts):
     # Mock the linux_shortcuts to return an empty dictionary
     utd_path, path, expected = utd_path_expected()
-    mock_linux_shortcuts.return_value = {"UTD": utd_path}
+    mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     utd_path, path, expected = utd_path_expected()
     result = datadok_extract.get_path_combinations(path)
+    print(sorted(result))
+    print(sorted(expected))
     assert sorted(result) == sorted(expected)
 
 
@@ -423,9 +401,11 @@ def test_get_path_combinations_basic(mock_get_key_by_value, mock_linux_shortcuts
 def test_get_path_combinations_with_dollar(mock_get_key_by_value, mock_linux_shortcuts):
     # Mock the linux_shortcuts to return a dictionary mapping
     utd_path, path, expected = utd_path_expected()
-    mock_linux_shortcuts.return_value = {"UTD": utd_path}
+    mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     result = datadok_extract.get_path_combinations(path)
+    print(sorted(result))
+    print(sorted(expected))
     assert sorted(result) == sorted(expected)
 
 
@@ -446,8 +426,15 @@ def utd_path_expected() -> tuple[str, str, list[tuple[str, str]]]:
         ("$UTD_PII/path/to/file", ".dat"),
         ("$UTD_PII/path/to/file", ".txt"),
     ]
-    expected = [(Path(p[0]), p[1],) for p in expected]
+    expected = [
+        (
+            Path(p[0]),
+            p[1],
+        )
+        for p in expected
+    ]
     return utd_path, path, expected
+
 
 @patch("fagfunksjoner.data.datadok_extract.linux_shortcuts")
 @patch("fagfunksjoner.data.dicts.get_key_by_value")
@@ -456,12 +443,13 @@ def test_get_path_combinations_with_non_dollar(
 ):
     # Mock the linux_shortcuts to return a dictionary mapping
     utd_path, path, expected = utd_path_expected()
-    mock_linux_shortcuts.return_value = {"UTD": utd_path}
+    mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     # Convert the paths to be OS-independent using os.path.join
     result = datadok_extract.get_path_combinations(path)
+    print(sorted(result))
+    print(sorted(expected))
     assert sorted(result) == sorted(expected)
-
 
 
 @patch("fagfunksjoner.data.datadok_extract.linux_shortcuts")
@@ -480,21 +468,22 @@ def test_get_path_combinations_with_invalid_dollar_key(
         datadok_extract.get_path_combinations("invalid/path/to/file")
 
 
-
 @patch("fagfunksjoner.data.datadok_extract.linux_shortcuts")
 @patch("fagfunksjoner.data.datadok_extract.get_key_by_value")
 @patch("fagfunksjoner.data.datadok_extract.import_archive_data")
 @patch("fagfunksjoner.data.datadok_extract.test_url")
-def test_file_with_ark_extension(mock_test_url, mock_import_archive_data, mock_get_key_by_value, mock_linux_shortcuts):
+def test_file_with_ark_extension(
+    mock_test_url, mock_import_archive_data, mock_get_key_by_value, mock_linux_shortcuts
+):
     utd_path, path, expected = utd_path_expected()
-    mock_linux_shortcuts.return_value = {"UTD": utd_path}
+    mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     mock_import_archive_data.return_value = pd.DataFrame()
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         ark_file = Path(tmpdirname, "file.ark")
-        ark_file.open('a').close()
+        ark_file.open("a").close()
         result = datadok_extract.open_path_datadok(ark_file)
         mock_import_archive_data.assert_called_once_with(ANY, ark_file)
         assert isinstance(result, pd.DataFrame)
@@ -504,16 +493,18 @@ def test_file_with_ark_extension(mock_test_url, mock_import_archive_data, mock_g
 @patch("fagfunksjoner.data.datadok_extract.get_key_by_value")
 @patch("fagfunksjoner.data.datadok_extract.import_archive_data")
 @patch("fagfunksjoner.data.datadok_extract.test_url")
-def test_file_with_ark_extension_finds_dat(mock_test_url, mock_import_archive_data, mock_get_key_by_value, mock_linux_shortcuts):
+def test_file_with_ark_extension_finds_dat(
+    mock_test_url, mock_import_archive_data, mock_get_key_by_value, mock_linux_shortcuts
+):
     utd_path, path, expected = utd_path_expected()
-    mock_linux_shortcuts.return_value = {"UTD": utd_path}
+    mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     mock_import_archive_data.return_value = pd.DataFrame()
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         ark_file = Path(tmpdirname, "file.dat")
-        ark_file.open('a').close()
+        ark_file.open("a").close()
         result = datadok_extract.open_path_datadok(ark_file.with_suffix(".ark"))
         mock_import_archive_data.assert_called_once_with(ANY, ark_file)
         assert isinstance(result, pd.DataFrame)

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -479,13 +479,14 @@ def test_file_with_ark_extension(
     mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     mock_import_archive_data.return_value = datadok_extract.ArchiveData(
-                                                        df=pd.DataFrame(),
-                                                        metadata_df=pd.DataFrame(),
-                                                        codelist_df=pd.DataFrame(),
-                                                        codelist_dict={"":{"":""}},
-                                                        names=[""],
-                                                        widths=[1],
-                                                        datatypes={"":""},)
+        df=pd.DataFrame(),
+        metadata_df=pd.DataFrame(),
+        codelist_df=pd.DataFrame(),
+        codelist_dict={"": {"": ""}},
+        names=[""],
+        widths=[1],
+        datatypes={"": ""},
+    )
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -507,13 +508,14 @@ def test_file_with_ark_extension_finds_dat(
     mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
     mock_import_archive_data.return_value = datadok_extract.ArchiveData(
-                                                        df=pd.DataFrame(),
-                                                        metadata_df=pd.DataFrame(),
-                                                        codelist_df=pd.DataFrame(),
-                                                        codelist_dict={"":{"":""}},
-                                                        names=[""],
-                                                        widths=[1],
-                                                        datatypes={"":""},)
+        df=pd.DataFrame(),
+        metadata_df=pd.DataFrame(),
+        codelist_df=pd.DataFrame(),
+        codelist_dict={"": {"": ""}},
+        names=[""],
+        widths=[1],
+        datatypes={"": ""},
+    )
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -521,4 +523,4 @@ def test_file_with_ark_extension_finds_dat(
         ark_file.open("a").close()
         result = datadok_extract.open_path_datadok(ark_file.with_suffix(".ark"))
         mock_import_archive_data.assert_called_once_with(ANY, ark_file)
-        assert isinstance(result, datadok_extract.ArchiveData )
+        assert isinstance(result, datadok_extract.ArchiveData)

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -483,9 +483,9 @@ def test_file_with_ark_extension(
                                                         metadata_df=pd.DataFrame(),
                                                         codelist_df=pd.DataFrame(),
                                                         codelist_dict={"":{"":""}},
-                                                        names=[""]
-                                                        widths=[1]
-                                                        datatypes={"":""})
+                                                        names=[""],
+                                                        widths=[1],
+                                                        datatypes={"":""},)
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/data/test_datadoc_extract.py
+++ b/tests/data/test_datadoc_extract.py
@@ -506,7 +506,14 @@ def test_file_with_ark_extension_finds_dat(
     utd_path, path, expected = utd_path_expected()
     mock_linux_shortcuts.return_value = {"UTD": str(utd_path.as_posix())}
     mock_get_key_by_value.return_value = "UTD"
-    mock_import_archive_data.return_value = pd.DataFrame()
+    mock_import_archive_data.return_value = datadok_extract.ArchiveData(
+                                                        df=pd.DataFrame(),
+                                                        metadata_df=pd.DataFrame(),
+                                                        codelist_df=pd.DataFrame(),
+                                                        codelist_dict={"":{"":""}},
+                                                        names=[""],
+                                                        widths=[1],
+                                                        datatypes={"":""},)
     mock_test_url.return_value = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -514,4 +521,4 @@ def test_file_with_ark_extension_finds_dat(
         ark_file.open("a").close()
         result = datadok_extract.open_path_datadok(ark_file.with_suffix(".ark"))
         mock_import_archive_data.assert_called_once_with(ANY, ark_file)
-        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result, datadok_extract.ArchiveData )

--- a/tests/paths/__init__.py
+++ b/tests/paths/__init__.py
@@ -1,1 +1,9 @@
 """Test path functionality in the fagfunksjoner package."""
+
+# Set logging level to debug during testing
+import logging
+
+import fagfunksjoner.fagfunksjoner_logger
+
+
+fagfunksjoner.fagfunksjoner_logger.logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Bumps version to 1.0.3

- Translated much more of Statistikkregister to use English
- Statistikkregister can find all the statistics of the owning section
- Datadok rewritten to use pathlib.Path, mainly with a goal of having the tests run on windows. Though they depend on posix paths in the "linux-stammer" so...
- @LucidCatnap wanted more robustness in the datadok-file search. It will now look for any matches, stripping the file extension. But if there is more than one match when doing this, it will raise a FileNotFoundError.