### PR TITLE
Version up package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-fagfunksjoner"
-version = "1.0.5"
+version = "1.0.6"
 description = "Fellesfunksjoner for ssb i Python"
 authors = ["SSB-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
The old limit of Python <3.13 is stuck in the published package, and is causing issues that might spread downstream, this merge is just to push changes already added to main. Depending on Python <4.0 instead.