### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Delete the text below, that does not apply, but please provide enough info so that we can reproduce what you are experiencing, in the same environment.
+
+** Environment **
+Dapla Lab / Old Dapla Jupyterlab / Jupyterlab bakke
+**IDE**
+VSCode / Jupyterlab
+**State**
+Staging / Prod
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
Adds a template for bug reports through issues in the repo.

We are getting bug reports without mention of IN WHICH ENVIRONMENT that this is experienced.

With 5+ environments, being detective every time is getting tiring. 
Maybe this could help people to specify Dapla Lab / Old dapla Jupyterlab / bakke / staging / prod / VsCode etc.
