### PR TITLE
Fix formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-fagfunksjoner"
-version = "1.0.8"
+version = "1.0.9"
 description = "Fellesfunksjoner for ssb i Python"
 authors = ["SSB-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"

--- a/src/fagfunksjoner/formats/formats.py
+++ b/src/fagfunksjoner/formats/formats.py
@@ -121,14 +121,15 @@ class SsbFormat(dict[Any, Any]):
             self.ranges[(bottom_float, top_float)] = value
 
     def look_in_ranges(self, key: str | int | float | NAType | None) -> None | Any:
-        """Looks for the specified key within the stored ranges.
+        """Returns the mapping value for the key if it falls within any defined range.
 
-        Args:
-            key: Key to search within the stored ranges.
-
-        Returns:
-            The value associated with the range containing the key, if found; otherwise, None.
+        The method attempts to convert the key to a float and then checks if it lies within
+        any of the stored range intervals. If the key is None, NA, or not of a convertible type,
+        the method returns None.
         """
+        if key is None or pd.isna(key) or not isinstance(key, str | int | float):
+            return None
+
         try:
             key_value = float(key)
         except (ValueError, TypeError):

--- a/src/fagfunksjoner/formats/formats.py
+++ b/src/fagfunksjoner/formats/formats.py
@@ -5,12 +5,12 @@ from typing import Any
 import pandas as pd
 from pandas._libs.missing import NAType
 
+
 SSBFORMAT_INPUT_TYPE = dict[str | int, Any] | dict[str, Any]
 
+
 class SsbFormat(dict[Any, Any]):
-    """Custom dictionary class designed to handle specific formatting conventions,
-    including mapping intervals (defined as range strings) even when they map to the same value.
-    """
+    """Custom dictionary class designed to handle specific formatting conventions, including mapping intervals (defined as range strings) even when they map to the same value."""
 
     def __init__(self, start_dict: SSBFORMAT_INPUT_TYPE | None = None) -> None:
         """Initializes the SsbFormat instance.
@@ -91,7 +91,7 @@ class SsbFormat(dict[Any, Any]):
 
     def store_ranges(self) -> None:
         """Stores ranges by converting range-string keys into tuple keys.
-        
+
         For example, a key "0-18" with value "A" will be stored as
         {(0.0, 18.0): "A"}.
         """
@@ -114,7 +114,9 @@ class SsbFormat(dict[Any, Any]):
         if (bottom_str.isdigit() or bottom_str.lower() == "low") and (
             top_str.isdigit() or top_str.lower() == "high"
         ):
-            bottom_float = float("-inf") if bottom_str.lower() == "low" else float(bottom_str)
+            bottom_float = (
+                float("-inf") if bottom_str.lower() == "low" else float(bottom_str)
+            )
             top_float = float("inf") if top_str.lower() == "high" else float(top_str)
             self.ranges[(bottom_float, top_float)] = value
 
@@ -164,7 +166,11 @@ class SsbFormat(dict[Any, Any]):
 
         If a key matching 'other' in any other case is found, its value is reassigned to 'other'.
         """
-        keys_to_update = [k for k in self if isinstance(k, str) and k.lower() == "other" and k != "other"]
+        keys_to_update = [
+            k
+            for k in self
+            if isinstance(k, str) and k.lower() == "other" and k != "other"
+        ]
         for k in keys_to_update:
             value = self[k]
             del self[k]

--- a/src/fagfunksjoner/formats/formats.py
+++ b/src/fagfunksjoner/formats/formats.py
@@ -104,15 +104,22 @@ class SsbFormat(dict[Any, Any]):
         """Converts a range-string key to a tuple of floats and stores it.
 
         Args:
-            key: Key to be converted to a tuple of floats.
-            value (Any): Value to be associated with the converted range.
+            key (str): A string representing a range in the format "lower-upper". The lower bound should be
+                       either a digit or "low" and the upper bound a digit or "high".
+            value (Any): The value to be associated with the converted range in the ranges dictionary.
+
+        Raises:
+            ValueError: If either the lower or upper bound contains a '.' character, indicating a float-like
+                        value instead of an integer-like value.
         """
         parts = key.split("-")
         if len(parts) != 2:
             return
         bottom_str, top_str = parts[0].strip(), parts[1].strip()
-        if '.' in bottom_str or '.' in top_str:
-            raise ValueError(f"Ranges must be int-like values not float-like {bottom_str}-{top_str}")
+        if "." in bottom_str or "." in top_str:
+            raise ValueError(
+                f"Ranges must be int-like values not float-like {bottom_str}-{top_str}"
+            )
         if (bottom_str.isdigit() or bottom_str.lower() == "low") and (
             top_str.isdigit() or top_str.lower() == "high"
         ):

--- a/src/fagfunksjoner/formats/formats.py
+++ b/src/fagfunksjoner/formats/formats.py
@@ -111,6 +111,8 @@ class SsbFormat(dict[Any, Any]):
         if len(parts) != 2:
             return
         bottom_str, top_str = parts[0].strip(), parts[1].strip()
+        if '.' in bottom_str or '.' in top_str:
+            raise ValueError(f"Ranges must be int-like values not float-like {bottom_str}-{top_str}")
         if (bottom_str.isdigit() or bottom_str.lower() == "low") and (
             top_str.isdigit() or top_str.lower() == "high"
         ):


### PR DESCRIPTION
Update SsbFormat to Support Overlapping and Open Intervals
This update refactors the SsbFormat class to enhance its handling of range-based mappings. Key improvements include:

Overlapping Interval Support:
Previously, mapping ranges that resulted in the same output (e.g., {"0-18": "A", "19-30": "A"}) could conflict. The updated implementation converts range keys into tuple keys (of floats), ensuring that each interval is stored independently—even if they map to the same value.

Open Interval Handling:
The update fully supports open intervals using "low" and "high". For example:
"low-18" is interpreted as (−∞,18]
"19-high" is interpreted as [19,+∞)
This makes it straightforward to define ranges with unbounded lower or upper limits.

Robustness Enhancements:
Additional updates ensure consistent handling of NA values and case normalization for the "other" key.

