### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/ssb-fagfunksjoner/security/code-scanning/3](https://github.com/statisticsnorway/ssb-fagfunksjoner/security/code-scanning/3)

To address the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the tasks performed in the workflow, we will grant only the necessary permissions. In this case:

- `contents: read` is required to read the repository contents.
- `pull-requests: write` may be needed if the workflow interacts with pull requests during code analysis or testing.
- Other permissions (e.g., `issues: write`, `packages: write`) are not needed for this workflow.

The `permissions` block will be added near the top of the workflow file, directly under the `name` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
